### PR TITLE
Validate POST /cells with zod; fix GET crash on corrupted notebook

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,12 +139,12 @@
 **Effort:** 4 hours
 **Impact:** Prevents bad data, better error messages
 
-- [ ] Install `zod` in local-api
-- [ ] Create Cell schema validation
-- [ ] Validate POST /cells request body
-- [ ] Return 400 with validation errors
-- [ ] Add request body size limits
-- [ ] Add tests for invalid inputs
+- [x] Install `zod` in local-api (PR #13)
+- [x] Create Cell schema validation, annotated with the shared wire types so it cannot drift (PR #13)
+- [x] Validate POST /cells request body (PR #13)
+- [x] Return 400 with validation errors (PR #13)
+- [x] Add request body size limits (5mb explicit; express default was 100kb) (PR #13)
+- [ ] Add tests for invalid inputs (deferred to item 10 — no test infrastructure yet; the cases were exercised manually against the running server)
 
 **Files:**
 - `jbook/packages/local-api/src/routes/cells.ts:33-42`

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -12667,6 +12667,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -13187,7 +13196,8 @@
       "dependencies": {
         "@my-scrapbook/local-client": "^3.0.0",
         "express": "^4.22.2",
-        "http-proxy-middleware": "^3.0.7"
+        "http-proxy-middleware": "^3.0.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@my-scrapbook/types": "^3.0.0",

--- a/jbook/packages/local-api/package.json
+++ b/jbook/packages/local-api/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@my-scrapbook/local-client": "^3.0.0",
     "express": "^4.22.2",
-    "http-proxy-middleware": "^3.0.7"
+    "http-proxy-middleware": "^3.0.7",
+    "zod": "^4.4.3"
   },
   "gitHead": "e297e727b7ac849fcbb530045a9ce6e41663364f"
 }

--- a/jbook/packages/local-api/src/routes/cells.ts
+++ b/jbook/packages/local-api/src/routes/cells.ts
@@ -1,11 +1,26 @@
 import express from "express";
 import fs from "fs/promises";
 import path from "path";
+import { z } from "zod";
 import { Cell, SaveCellsRequest, SaveCellsResponse } from "@my-scrapbook/types";
+
+// Schemas are annotated with the shared wire types so they cannot drift from
+// the contract in @my-scrapbook/types.
+const cellSchema: z.ZodType<Cell> = z.object({
+  id: z.string().min(1),
+  type: z.enum(["code", "text"]),
+  content: z.string(),
+});
+
+const saveCellsRequestSchema: z.ZodType<SaveCellsRequest> = z.object({
+  cells: z.array(cellSchema),
+});
 
 export const createCellsRouter = (filename: string, dir: string) => {
   const router = express.Router();
-  router.use(express.json());
+  // Explicit body size limit; the express default (100kb) is small enough
+  // that a large notebook could fail to save.
+  router.use(express.json({ limit: "5mb" }));
 
   const fullPath = path.join(dir, filename);
 
@@ -20,18 +35,29 @@ export const createCellsRouter = (filename: string, dir: string) => {
         await fs.writeFile(fullPath, "[]", "utf-8");
         res.send([]);
       } else {
-        throw err;
+        // Rethrowing from an async express 4 handler is an unhandled
+        // rejection and would take down the server (e.g. on a notebook file
+        // with invalid JSON); answer with a 500 instead.
+        res.status(500).send({
+          error: `Could not read ${filename}: ${err.message}`,
+        });
       }
     }
   });
 
   router.post("/cells", async (req, res) => {
-    // Take the list of cells from the request obj
-    // serialize them
-    const { cells }: { cells: Cell[] } = req.body as SaveCellsRequest;
+    const parsed = saveCellsRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).send({
+        error: "Invalid cells payload",
+        issues: parsed.error.issues,
+      });
+      return;
+    }
 
     // Write the cells into the file
-    await fs.writeFile(fullPath, JSON.stringify(cells), "utf-8");
+    await fs.writeFile(fullPath, JSON.stringify(parsed.data.cells), "utf-8");
 
     const response: SaveCellsResponse = { status: "ok" };
     res.send(response);


### PR DESCRIPTION
## Summary

Ninth PR of the repo update plan (stacked on #12 → … → #6). Implements TODO item 8, plus one adjacent robustness fix found while in the file.

### Validation (TODO item 8)
- `POST /cells` now validates its body with **zod** schemas that are annotated with the shared `@my-scrapbook/types` wire types (`z.ZodType<SaveCellsRequest>`) — the schema and the published contract cannot drift apart.
- Invalid payloads → **400** with zod's structured issue list (path + message per problem).
- Unknown keys on cells are **stripped before writing to disk** (zod object default), so junk can't be persisted into `notebook.js`.
- The JSON body limit is explicit at **5mb** — worth noting express's default was 100kb, which a large notebook could already exceed; oversized bodies now get a clean **413**.

### Crash fix (adjacent, same file)
`GET /cells` rethrew read/parse errors from an async express 4 handler — that's an **unhandled promise rejection**, which terminates the Node process on modern versions. Concretely: a hand-edited or corrupted `notebook.js` would crash the whole server on page load. It now responds 500 with the parse error message and keeps serving.

The TODO's "add tests for invalid inputs" sub-item is deferred to item 10 (there's still no test runner); the full case matrix was exercised manually instead (below).

## Verification

Against the rebuilt CLI serving the app:

| Case | Result |
|---|---|
| Valid payload | 200 `{"status":"ok"}`, file written |
| `type: "markdown"` (bad enum) | 400 with issue at `cells/0/type` |
| Missing `content` | 400 |
| `cells` not an array | 400 |
| Extra key `evil` on a cell | 200, key stripped from `notebook.js` |
| 6 MB body | 413 |
| Corrupted `notebook.js` on GET | 500 with parse message; **server still serving afterward** (previously: process crash) |