### PR TITLE
Extract timing constants; improve CLI error output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,11 +57,11 @@
 **Effort:** 1 hour
 **Impact:** Improves readability and configurability
 
-- [ ] Create `jbook/packages/local-client/src/constants.ts`
-- [ ] Extract `BUNDLE_DEBOUNCE_MS = 750`
-- [ ] Extract `PERSIST_DEBOUNCE_MS = 250`
-- [ ] Extract `RANDOM_ID_LENGTH = 5` (if keeping random IDs)
-- [ ] Document why each value was chosen
+- [x] Create `jbook/packages/local-client/src/constants.ts` (PR #15)
+- [x] Extract `BUNDLE_DEBOUNCE_MS = 750` (PR #15)
+- [x] Extract `PERSIST_SAVE_DEBOUNCE_MS = 250` (plus the JSX-highlight and preview-execute delays found along the way) (PR #15)
+- [x] ~~Extract `RANDOM_ID_LENGTH = 5`~~ obsolete — cell IDs are UUIDs since PR #10
+- [x] Document why each value was chosen (PR #15)
 
 **Files:**
 - `jbook/packages/local-client/src/components/code-cell.tsx:27`
@@ -74,10 +74,10 @@
 **Effort:** 2 hours
 **Impact:** Better error messages, easier debugging
 
-- [ ] Fix typo: "Heres the problem" → "Here's the problem"
-- [ ] Add structured error messages with error codes
-- [ ] Consider adding winston/pino for structured logging
-- [ ] Add error context (file, port, command)
+- [x] Fix the serve error output (typo gone; message now carries file + port context) (PR #15)
+- [x] Add structured error messages (EADDRINUSE handled by code with an actionable hint; other failures report file, port, and cause) (PR #15)
+- [x] Considered winston/pino and decided against: the CLI emits two messages total; a logging framework adds a runtime dependency for no benefit at this size (PR #15)
+- [x] Add error context (file, port, suggested command) (PR #15)
 
 **Files:**
 - `jbook/packages/cli/src/commands/serve.ts:27`

--- a/jbook/packages/cli/src/commands/serve.ts
+++ b/jbook/packages/cli/src/commands/serve.ts
@@ -20,11 +20,17 @@ export const serveCommand = new Command()
       console.log(
         `Opened ${filename}. Navigate to http://localhost:${options.port} to edit the file.`
       );
-    } catch (err: any) {
-      if (err.code === "EADDRINUSE") {
-        console.error("Port is in use. Try running on a different port.");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EADDRINUSE") {
+        console.error(
+          `Port ${options.port} is already in use. Pick another with: my-scrapbook serve ${filename} -p <port>`
+        );
       } else {
-        console.log("Heres the problem", err.message);
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(
+          `Failed to open ${filename} on port ${options.port}: ${message}`
+        );
       }
       process.exit(1);
     }

--- a/jbook/packages/local-api/src/routes/cells.ts
+++ b/jbook/packages/local-api/src/routes/cells.ts
@@ -16,11 +16,13 @@ const saveCellsRequestSchema: z.ZodType<SaveCellsRequest> = z.object({
   cells: z.array(cellSchema),
 });
 
+// Explicit body size limit; the express default (100kb) is small enough that
+// a large notebook could fail to save.
+const MAX_NOTEBOOK_BODY_SIZE = "5mb";
+
 export const createCellsRouter = (filename: string, dir: string) => {
   const router = express.Router();
-  // Explicit body size limit; the express default (100kb) is small enough
-  // that a large notebook could fail to save.
-  router.use(express.json({ limit: "5mb" }));
+  router.use(express.json({ limit: MAX_NOTEBOOK_BODY_SIZE }));
 
   const fullPath = path.join(dir, filename);
 

--- a/jbook/packages/local-client/src/components/code-cell.tsx
+++ b/jbook/packages/local-client/src/components/code-cell.tsx
@@ -4,6 +4,7 @@ import CodeEditor from './code-editor';
 import Preview from './preview';
 import Resizable from './resizable';
 import { Cell } from '../state';
+import { BUNDLE_DEBOUNCE_MS } from '../constants';
 import { useActions } from '../hooks/use-actions';
 import { useTypedSelector } from '../hooks/use-typed-selector';
 import { useCumulativeCode } from '../hooks/use-cumulative-code';
@@ -25,7 +26,7 @@ const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
 
     const timer = setTimeout(async () => {
       createBundle(cell.id, cumulativeCode);
-    }, 750);
+    }, BUNDLE_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timer);

--- a/jbook/packages/local-client/src/components/code-editor.tsx
+++ b/jbook/packages/local-client/src/components/code-editor.tsx
@@ -7,6 +7,7 @@ import parser from 'prettier/parser-babel';
 import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
 import MonacoJSXHighlighter, { makeBabelParse } from 'monaco-jsx-highlighter';
+import { JSX_HIGHLIGHT_DEBOUNCE_MS } from '../constants';
 
 // Configures @babel/parser for module source type + JSX with error recovery;
 // the raw parse function rejects top-level import/export statements.
@@ -34,7 +35,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ onChange, initialValue }) => {
     // Silence the parse/highlight error handlers: user code is routinely
     // invalid mid-keystroke and the defaults log every attempt.
     highlighter.highlightOnDidChangeModelContent(
-      100,
+      JSX_HIGHLIGHT_DEBOUNCE_MS,
       undefined,
       () => {},
       undefined,

--- a/jbook/packages/local-client/src/components/preview.tsx
+++ b/jbook/packages/local-client/src/components/preview.tsx
@@ -1,5 +1,6 @@
 import './preview.css';
 import { useRef, useEffect } from 'react';
+import { PREVIEW_EXECUTE_DELAY_MS } from '../constants';
 
 interface PreviewProps {
   code: string;
@@ -44,7 +45,7 @@ const Preview: React.FC<PreviewProps> = ({ code, err }) => {
     iframe.current.srcdoc = html;
     setTimeout(() => {
       iframe.current.contentWindow.postMessage(code, '*');
-    }, 50);
+    }, PREVIEW_EXECUTE_DELAY_MS);
   }, [code]);
 
   return (

--- a/jbook/packages/local-client/src/constants.ts
+++ b/jbook/packages/local-client/src/constants.ts
@@ -1,0 +1,20 @@
+// Delay after the last keystroke before re-bundling a code cell. Long enough
+// that esbuild-wasm isn't re-run on every keypress (bundling also refetches
+// any uncached unpkg modules), short enough that the preview feels live.
+export const BUNDLE_DEBOUNCE_MS = 750;
+
+// Delay after the last cell change before persisting the notebook to disk.
+// Shorter than BUNDLE_DEBOUNCE_MS on purpose: saving is a cheap local POST,
+// and a shorter window narrows the span in which a crash loses work.
+export const PERSIST_SAVE_DEBOUNCE_MS = 250;
+
+// Delay before the JSX highlighter re-parses the buffer after an edit; the
+// library's own default. Parsing with @babel/parser is fast, so this mainly
+// coalesces bursts of keystrokes.
+export const JSX_HIGHLIGHT_DEBOUNCE_MS = 100;
+
+// Pause between resetting the preview iframe's srcdoc and posting the bundled
+// code into it, giving the fresh document time to install its message
+// listener. A load-event handshake would be more principled; this matches the
+// app's long-standing behavior.
+export const PREVIEW_EXECUTE_DELAY_MS = 50;

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
@@ -4,6 +4,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import cellsReducer, { fetchCells, updateCell, deleteCell } from '../cells-slice';
 import bundlesReducer from '../bundles-slice';
 import { persistMiddleware } from './persist-middleware';
+import { PERSIST_SAVE_DEBOUNCE_MS } from '../../constants';
 
 vi.mock('axios');
 vi.mock('../../bundler', () => ({ default: vi.fn() }));
@@ -34,13 +35,13 @@ describe('persist middleware', () => {
     vi.useRealTimers();
   });
 
-  it('saves after a cell-changing action, debounced at 250ms', async () => {
+  it('saves after a cell-changing action, debounced', async () => {
     const store = makeStore();
 
     store.dispatch(updateCell('a', 'show(1);'));
     expect(axios.post).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
     expect(axios.post).toHaveBeenCalledTimes(1);
   });
 
@@ -52,7 +53,7 @@ describe('persist middleware', () => {
     store.dispatch(updateCell('a', 'sh'));
     await vi.advanceTimersByTimeAsync(100);
     store.dispatch(deleteCell('a'));
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
 
     expect(axios.post).toHaveBeenCalledTimes(1);
   });

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
@@ -7,6 +7,7 @@ import {
   updateCell,
 } from '../cells-slice';
 import type { AppDispatch } from '../store';
+import { PERSIST_SAVE_DEBOUNCE_MS } from '../../constants';
 
 const isPersistTrigger = isAnyOf(
   updateCell,
@@ -29,7 +30,7 @@ export const persistMiddleware: Middleware = ({ dispatch }) => {
       }
       timer = setTimeout(() => {
         (dispatch as AppDispatch)(saveCells());
-      }, 250);
+      }, PERSIST_SAVE_DEBOUNCE_MS);
     }
 
     return result;


### PR DESCRIPTION
## Summary

Eleventh and final PR of the repo update plan (stacked on #14 → … → #6). Implements TODO items 4 and 5 — the last two open work items.

### Magic numbers (item 4)
New documented [`constants.ts`](jbook/packages/local-client/src/constants.ts) in local-client, with a why-comment on each value:

| Constant | Value | Previously |
|---|---|---|
| `BUNDLE_DEBOUNCE_MS` | 750 | bare literal in code-cell |
| `PERSIST_SAVE_DEBOUNCE_MS` | 250 | bare literal in persist middleware |
| `JSX_HIGHLIGHT_DEBOUNCE_MS` | 100 | bare literal in code-editor (not in the TODO's list) |
| `PREVIEW_EXECUTE_DELAY_MS` | 50 | bare literal in preview (not in the TODO's list) |

The persist-middleware test now advances its fake timers by the constant, so retuning the debounce can't silently desynchronize the test. local-api's JSON body limit becomes a named `MAX_NOTEBOOK_BODY_SIZE`. The TODO's `RANDOM_ID_LENGTH` entry is obsolete — cell IDs have been UUIDs since #10.

### CLI error output (item 5)
- `EADDRINUSE` now names the occupied port and prints the exact fix: `Port 4005 is already in use. Pick another with: my-scrapbook serve notebook.js -p <port>`
- Every other failure reports file, port, and cause — on **stderr** (the old path logged `Heres the problem` to stdout), with the `err: any` cast replaced by proper narrowing
- **winston/pino considered and rejected**, per the TODO's ask: the CLI emits two messages total; a logging framework is a runtime dependency for no benefit at this size. The decision is recorded in TODO.md rather than left as an open question.

## Verification
- All 36 tests green in both packages; all builds green (client, api, cli)
- Live smoke test of the error path: started two servers on the same port — the second printed the new port-conflict message verbatim and exited 1

With this, **every P0–P2 item in TODO.md is either done or explicitly resolved**; what remains are the P3 feature ideas and the npm-publish decision.