### PR TITLE
Add notebook-level undo/redo

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -242,12 +242,12 @@
 **Effort:** 1 week
 **Impact:** Professional editor experience
 
-- [ ] Install `redux-undo` or implement custom middleware
-- [ ] Add undo/redo to cell updates
-- [ ] Add keyboard shortcuts (Ctrl+Z, Ctrl+Y)
-- [ ] Add undo/redo buttons in UI
-- [ ] Limit history depth (e.g., 50 actions)
-- [ ] Don't track every keystroke (debounce)
+- [x] Install `redux-undo` (PR #20)
+- [x] Add undo/redo to cell updates, deletes, moves, and inserts (PR #20)
+- [x] Add keyboard shortcuts (Ctrl/Cmd+Z, Ctrl+Y, Ctrl/Cmd+Shift+Z), deferring to Monaco/markdown editors when focus is inside them (PR #20)
+- [x] Add undo/redo buttons in UI with disabled states (PR #20)
+- [x] Limit history depth (50 states) (PR #20)
+- [x] Don't track every keystroke (consecutive edits to a cell group into one history entry) (PR #20)
 
 ---
 

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -2593,13 +2593,6 @@
         }
       }
     },
-    "node_modules/@reduxjs/toolkit/node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -11895,6 +11888,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redux-undo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/redux-undo/-/redux-undo-1.1.0.tgz",
+      "integrity": "sha512-zzLFh2qeF0MTIlzDhDLm9NtkfBqCllQJ3OCuIl5RKlG/ayHw6GUdIFdMhzMS9NnrnWdBX5u//ExMOHpfudGGOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/refractor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
@@ -15086,6 +15093,8 @@
         "react-dom": "^18.3.1",
         "react-redux": "^9.3.0",
         "react-resizable": "^3.0.5",
+        "redux": "^5.0.1",
+        "redux-undo": "^1.1.0",
         "typescript": "^5.9.3",
         "uuid": "^11.1.1",
         "vite": "^7.3.6",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -47,6 +47,8 @@
     "react-dom": "^18.3.1",
     "react-redux": "^9.3.0",
     "react-resizable": "^3.0.5",
+    "redux": "^5.0.1",
+    "redux-undo": "^1.1.0",
     "typescript": "^5.9.3",
     "uuid": "^11.1.1",
     "vite": "^7.3.6",

--- a/jbook/packages/local-client/src/components/action-bar.test.tsx
+++ b/jbook/packages/local-client/src/components/action-bar.test.tsx
@@ -20,10 +20,10 @@ describe('ActionBar', () => {
     const [up, down] = screen.getAllByRole('button');
 
     await user.click(up);
-    expect(store.getState().cells.order).toEqual(['b', 'a']);
+    expect(store.getState().cells.present.order).toEqual(['b', 'a']);
 
     await user.click(down);
-    expect(store.getState().cells.order).toEqual(['a', 'b']);
+    expect(store.getState().cells.present.order).toEqual(['a', 'b']);
   });
 
   it('deletes the cell through the store', async () => {
@@ -34,7 +34,7 @@ describe('ActionBar', () => {
     const buttons = screen.getAllByRole('button');
     await user.click(buttons[2]);
 
-    expect(store.getState().cells.order).toEqual(['b']);
-    expect(store.getState().cells.data['a']).toBeUndefined();
+    expect(store.getState().cells.present.order).toEqual(['b']);
+    expect(store.getState().cells.present.data['a']).toBeUndefined();
   });
 });

--- a/jbook/packages/local-client/src/components/add-cell.test.tsx
+++ b/jbook/packages/local-client/src/components/add-cell.test.tsx
@@ -16,7 +16,7 @@ describe('AddCell', () => {
 
     await user.click(screen.getByRole('button', { name: /code/i }));
 
-    const { order, data } = store.getState().cells;
+    const { order, data } = store.getState().cells.present;
     expect(order).toHaveLength(2);
     expect(order[0]).toBe('a');
     expect(data[order[1]].type).toBe('code');
@@ -29,7 +29,7 @@ describe('AddCell', () => {
 
     await user.click(screen.getByRole('button', { name: /text/i }));
 
-    const { order, data } = store.getState().cells;
+    const { order, data } = store.getState().cells.present;
     expect(order).toHaveLength(2);
     expect(order[1]).toBe('a');
     expect(data[order[0]].type).toBe('text');

--- a/jbook/packages/local-client/src/components/cell-list.tsx
+++ b/jbook/packages/local-client/src/components/cell-list.tsx
@@ -1,15 +1,18 @@
 import "./cell-list.css";
 import { Fragment, useEffect } from "react";
 import { useTypedSelector } from "../hooks/use-typed-selector";
+import { selectCells } from "../state";
 import CellListItem from "./cell-list-item";
 import AddCell from "./add-cell";
 import ErrorBoundary from "./error-boundary";
+import UndoRedoBar from "./undo-redo-bar";
 import { useActions } from "../hooks/use-actions";
 
 const CellList: React.FC = () => {
-  const cells = useTypedSelector(({ cells: { order, data } }) =>
-    order.map((id) => data[id])
-  );
+  const cells = useTypedSelector((state) => {
+    const { order, data } = selectCells(state);
+    return order.map((id) => data[id]);
+  });
   const { fetchCells } = useActions();
 
   useEffect(() => {
@@ -27,6 +30,7 @@ const CellList: React.FC = () => {
 
   return (
     <div className="cell-list">
+      <UndoRedoBar />
       <AddCell forceVisible={cells.length === 0} previousCellId={null} />
       {renderedCells}
     </div>

--- a/jbook/packages/local-client/src/components/text-editor.test.tsx
+++ b/jbook/packages/local-client/src/components/text-editor.test.tsx
@@ -56,7 +56,7 @@ describe('TextEditor', () => {
     expect(editor).toBeInTheDocument();
 
     fireEvent.change(editor, { target: { value: '# Hello world' } });
-    expect(store.getState().cells.data['t1'].content).toBe('# Hello world');
+    expect(store.getState().cells.present.data['t1'].content).toBe('# Hello world');
   });
 
   it('closes the editor when clicking outside', async () => {

--- a/jbook/packages/local-client/src/components/undo-redo-bar.css
+++ b/jbook/packages/local-client/src/components/undo-redo-bar.css
@@ -1,0 +1,10 @@
+.undo-redo-bar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 5px;
+  padding: 5px 10px 0 10px;
+}
+
+.undo-redo-bar .button[disabled] {
+  opacity: 0.4;
+}

--- a/jbook/packages/local-client/src/components/undo-redo-bar.test.tsx
+++ b/jbook/packages/local-client/src/components/undo-redo-bar.test.tsx
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from 'vitest';
+import { act, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UndoRedoBar from './undo-redo-bar';
+import { makeStore, renderWithStore } from '../test-utils';
+import { updateCell } from '../state/cells-slice';
+import { Cell } from '../state/cell';
+
+const cell: Cell = { id: 'a', type: 'code', content: 'original' };
+
+describe('UndoRedoBar', () => {
+  it('disables both buttons with no history', () => {
+    renderWithStore(<UndoRedoBar />, makeStore([cell]));
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+  });
+
+  it('undoes and redoes edits via the buttons', async () => {
+    const user = userEvent.setup();
+    const store = makeStore([cell]);
+    renderWithStore(<UndoRedoBar />, store);
+
+    act(() => {
+      store.dispatch(updateCell('a', 'edited'));
+    });
+    const undo = screen.getByRole('button', { name: 'Undo' });
+    expect(undo).toBeEnabled();
+
+    await user.click(undo);
+    expect(store.getState().cells.present.data['a'].content).toBe('original');
+
+    const redo = screen.getByRole('button', { name: 'Redo' });
+    expect(redo).toBeEnabled();
+    await user.click(redo);
+    expect(store.getState().cells.present.data['a'].content).toBe('edited');
+  });
+
+  it('handles Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y shortcuts', () => {
+    const store = makeStore([cell]);
+    renderWithStore(<UndoRedoBar />, store);
+    act(() => {
+      store.dispatch(updateCell('a', 'edited'));
+    });
+
+    fireEvent.keyDown(document.body, { key: 'z', ctrlKey: true });
+    expect(store.getState().cells.present.data['a'].content).toBe('original');
+
+    fireEvent.keyDown(document.body, { key: 'z', ctrlKey: true, shiftKey: true });
+    expect(store.getState().cells.present.data['a'].content).toBe('edited');
+
+    fireEvent.keyDown(document.body, { key: 'z', ctrlKey: true });
+    fireEvent.keyDown(document.body, { key: 'y', ctrlKey: true });
+    expect(store.getState().cells.present.data['a'].content).toBe('edited');
+  });
+
+  it('supports Cmd+Z on macOS', () => {
+    const store = makeStore([cell]);
+    renderWithStore(<UndoRedoBar />, store);
+    act(() => {
+      store.dispatch(updateCell('a', 'edited'));
+    });
+
+    fireEvent.keyDown(document.body, { key: 'z', metaKey: true });
+    expect(store.getState().cells.present.data['a'].content).toBe('original');
+  });
+
+  it('does not hijack the shortcut while typing in a text input', () => {
+    const store = makeStore([cell]);
+    renderWithStore(
+      <div>
+        <UndoRedoBar />
+        <textarea aria-label="editor stand-in" />
+      </div>,
+      store
+    );
+    act(() => {
+      store.dispatch(updateCell('a', 'edited'));
+    });
+
+    fireEvent.keyDown(screen.getByLabelText('editor stand-in'), {
+      key: 'z',
+      ctrlKey: true,
+    });
+
+    // the notebook-level undo must not fire; the input owns its own undo
+    expect(store.getState().cells.present.data['a'].content).toBe('edited');
+  });
+});

--- a/jbook/packages/local-client/src/components/undo-redo-bar.tsx
+++ b/jbook/packages/local-client/src/components/undo-redo-bar.tsx
@@ -1,0 +1,80 @@
+import './undo-redo-bar.css';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { ActionCreators } from 'redux-undo';
+import { useTypedSelector } from '../hooks/use-typed-selector';
+import { selectCanRedo, selectCanUndo } from '../state';
+
+// Text inputs manage their own undo stacks (Monaco has a full one); the
+// notebook-level shortcuts must not fire while the user is typing in one.
+const isEditingText = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target.closest('.monaco-editor, .w-md-editor') !== null ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLInputElement ||
+    target.isContentEditable
+  );
+};
+
+const UndoRedoBar: React.FC = () => {
+  const dispatch = useDispatch();
+  const canUndo = useTypedSelector(selectCanUndo);
+  const canRedo = useTypedSelector(selectCanRedo);
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) {
+        return;
+      }
+      if (isEditingText(event.target)) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      if (key === 'z' && !event.shiftKey) {
+        event.preventDefault();
+        dispatch(ActionCreators.undo());
+      } else if (key === 'y' || (key === 'z' && event.shiftKey)) {
+        event.preventDefault();
+        dispatch(ActionCreators.redo());
+      }
+    };
+
+    document.addEventListener('keydown', listener);
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
+  }, [dispatch]);
+
+  return (
+    <div className="undo-redo-bar">
+      <button
+        className="button is-primary is-small"
+        disabled={!canUndo}
+        title="Undo (Ctrl+Z)"
+        aria-label="Undo"
+        onClick={() => dispatch(ActionCreators.undo())}
+      >
+        <span className="icon">
+          <i className="fas fa-undo"></i>
+        </span>
+      </button>
+      <button
+        className="button is-primary is-small"
+        disabled={!canRedo}
+        title="Redo (Ctrl+Y)"
+        aria-label="Redo"
+        onClick={() => dispatch(ActionCreators.redo())}
+      >
+        <span className="icon">
+          <i className="fas fa-redo"></i>
+        </span>
+      </button>
+    </div>
+  );
+};
+
+export default UndoRedoBar;

--- a/jbook/packages/local-client/src/constants.ts
+++ b/jbook/packages/local-client/src/constants.ts
@@ -18,3 +18,8 @@ export const JSX_HIGHLIGHT_DEBOUNCE_MS = 100;
 // listener. A load-event handshake would be more principled; this matches the
 // app's long-standing behavior.
 export const PREVIEW_EXECUTE_DELAY_MS = 50;
+
+// Maximum number of undo history entries kept for the notebook. Snapshots are
+// cheap (cells are small JSON), and 50 comfortably covers a working session
+// without unbounded growth.
+export const UNDO_HISTORY_LIMIT = 50;

--- a/jbook/packages/local-client/src/hooks/use-cumulative-code.ts
+++ b/jbook/packages/local-client/src/hooks/use-cumulative-code.ts
@@ -1,8 +1,9 @@
 import { useTypedSelector } from './use-typed-selector';
+import { selectCells } from '../state';
 
 export const useCumulativeCode = (cellId: string) => {
   return useTypedSelector((state) => {
-    const { data, order } = state.cells;
+    const { data, order } = selectCells(state);
     const orderedCells = order.map((id) => data[id]);
 
     const showFunc = `

--- a/jbook/packages/local-client/src/state/cells-slice.test.ts
+++ b/jbook/packages/local-client/src/state/cells-slice.test.ts
@@ -10,6 +10,7 @@ import reducer, {
   updateCell,
 } from './cells-slice';
 import { Cell } from './cell';
+import { undoableCellsReducer } from './store';
 
 vi.mock('axios');
 
@@ -85,7 +86,8 @@ describe('fetch/save thunks', () => {
     vi.mocked(axios.post).mockReset();
   });
 
-  const makeStore = () => configureStore({ reducer: { cells: reducer } });
+  const makeStore = () =>
+    configureStore({ reducer: { cells: undoableCellsReducer } });
 
   it('fetchCells loads cells into state', async () => {
     vi.mocked(axios.get).mockResolvedValue({ data: [cellA, cellB] });
@@ -93,7 +95,7 @@ describe('fetch/save thunks', () => {
 
     await store.dispatch(fetchCells());
 
-    const { cells } = store.getState();
+    const { present: cells } = store.getState().cells;
     expect(cells.loading).toBe(false);
     expect(cells.order).toEqual(['a', 'b']);
     expect(cells.data['b']).toEqual(cellB);
@@ -105,7 +107,7 @@ describe('fetch/save thunks', () => {
 
     await store.dispatch(fetchCells());
 
-    const { cells } = store.getState();
+    const { present: cells } = store.getState().cells;
     expect(cells.loading).toBe(false);
     expect(cells.error).toBe('nope');
   });
@@ -129,6 +131,6 @@ describe('fetch/save thunks', () => {
 
     await store.dispatch(saveCells());
 
-    expect(store.getState().cells.error).toBe('disk full');
+    expect(store.getState().cells.present.error).toBe('disk full');
   });
 });

--- a/jbook/packages/local-client/src/state/cells-slice.ts
+++ b/jbook/packages/local-client/src/state/cells-slice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { StateWithHistory } from 'redux-undo';
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import type { FetchCellsResponse, SaveCellsRequest } from '@my-scrapbook/types';
@@ -6,7 +7,7 @@ import { Cell, CellTypes } from './cell';
 
 export type Direction = 'up' | 'down';
 
-interface CellsState {
+export interface CellsState {
   loading: boolean;
   error: string | null;
   order: string[];
@@ -29,13 +30,17 @@ export const fetchCells = createAsyncThunk('cells/fetchCells', async () => {
 
 // The state type is declared structurally instead of importing RootState from
 // the store, which would create an import cycle (store -> slice -> store).
+// The cells slice is wrapped in redux-undo history at the store level, so the
+// current notebook lives under `present`.
 export const saveCells = createAsyncThunk<
   void,
   void,
-  { state: { cells: CellsState } }
+  { state: { cells: StateWithHistory<CellsState> } }
 >('cells/saveCells', async (_, { getState }) => {
   const {
-    cells: { data, order },
+    cells: {
+      present: { data, order },
+    },
   } = getState();
 
   const cells = order.map((id) => data[id]);

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import axios from 'axios';
 import { configureStore } from '@reduxjs/toolkit';
-import cellsReducer, { fetchCells, updateCell, deleteCell } from '../cells-slice';
+import { fetchCells, updateCell, deleteCell } from '../cells-slice';
+import { undoableCellsReducer } from '../store';
 import bundlesReducer from '../bundles-slice';
 import { persistMiddleware } from './persist-middleware';
 import { PERSIST_SAVE_DEBOUNCE_MS } from '../../constants';
@@ -11,7 +12,7 @@ vi.mock('../../bundler', () => ({ default: vi.fn() }));
 
 const makeStore = () => {
   const store = configureStore({
-    reducer: { cells: cellsReducer, bundles: bundlesReducer },
+    reducer: { cells: undoableCellsReducer, bundles: bundlesReducer },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(persistMiddleware),
   });
@@ -56,6 +57,23 @@ describe('persist middleware', () => {
     await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
 
     expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves after undo and redo', async () => {
+    const { ActionCreators } = await import('redux-undo');
+    const store = makeStore();
+
+    store.dispatch(updateCell('a', 'show(1);'));
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
+    expect(axios.post).toHaveBeenCalledTimes(1);
+
+    store.dispatch(ActionCreators.undo());
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
+    expect(axios.post).toHaveBeenCalledTimes(2);
+
+    store.dispatch(ActionCreators.redo());
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
+    expect(axios.post).toHaveBeenCalledTimes(3);
   });
 
   it('does not save on non-cell actions', async () => {

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
@@ -1,4 +1,5 @@
 import { isAnyOf, Middleware } from '@reduxjs/toolkit';
+import { ActionTypes as UndoActionTypes } from 'redux-undo';
 import {
   deleteCell,
   insertCellAfter,
@@ -9,12 +10,13 @@ import {
 import type { AppDispatch } from '../store';
 import { PERSIST_SAVE_DEBOUNCE_MS } from '../../constants';
 
-const isPersistTrigger = isAnyOf(
-  updateCell,
-  deleteCell,
-  moveCell,
-  insertCellAfter
-);
+const isCellEdit = isAnyOf(updateCell, deleteCell, moveCell, insertCellAfter);
+
+// Undo/redo restore a different notebook state and must be persisted too.
+const isPersistTrigger = (action: unknown): boolean =>
+  isCellEdit(action) ||
+  (action as { type?: string }).type === UndoActionTypes.UNDO ||
+  (action as { type?: string }).type === UndoActionTypes.REDO;
 
 // Debounces a saveCells dispatch after any action that changes cell content
 // or ordering.

--- a/jbook/packages/local-client/src/state/store.ts
+++ b/jbook/packages/local-client/src/state/store.ts
@@ -1,11 +1,44 @@
-import { configureStore } from '@reduxjs/toolkit';
-import cellsReducer from './cells-slice';
+import { configureStore, Reducer } from '@reduxjs/toolkit';
+import undoable, { includeAction, StateWithHistory } from 'redux-undo';
+import cellsReducer, {
+  CellsState,
+  deleteCell,
+  insertCellAfter,
+  moveCell,
+  updateCell,
+} from './cells-slice';
 import bundlesReducer from './bundles-slice';
 import { persistMiddleware } from './middlewares/persist-middleware';
+import { UNDO_HISTORY_LIMIT } from '../constants';
+
+// Exported so tests can build stores with the exact same history behavior.
+// The cast bridges redux-undo's redux-4-era Reducer typing to redux 5.
+export const undoableCellsReducer = undoable(cellsReducer, {
+  limit: UNDO_HISTORY_LIMIT,
+  // Only user edits are undoable; fetch/save lifecycle actions update the
+  // present state without creating history entries, so undo can never
+  // rewind past the initially loaded notebook.
+  filter: includeAction([
+    updateCell.type,
+    deleteCell.type,
+    moveCell.type,
+    insertCellAfter.type,
+  ]),
+  // Keep the internal snapshot in sync when filtered actions (like the
+  // initial fetch) change the present state; without this, the first undo
+  // would rewind to the pre-fetch empty notebook.
+  syncFilter: true,
+  // Consecutive keystrokes produce a stream of updateCell actions; group
+  // them per cell into a single history entry so undo reverts the typing
+  // burst in that cell, not one character — and switching to a different
+  // cell starts a new entry.
+  groupBy: (action) =>
+    updateCell.match(action) ? `${action.type}:${action.payload.id}` : null,
+}) as Reducer<StateWithHistory<CellsState>>;
 
 export const store = configureStore({
   reducer: {
-    cells: cellsReducer,
+    cells: undoableCellsReducer,
     bundles: bundlesReducer,
   },
   middleware: (getDefaultMiddleware) =>
@@ -14,3 +47,10 @@ export const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+// The cells slice is wrapped in redux-undo history; consumers read the
+// current notebook through this selector rather than state.cells directly.
+export const selectCells = (state: RootState) => state.cells.present;
+export const selectCanUndo = (state: RootState) => state.cells.past.length > 0;
+export const selectCanRedo = (state: RootState) =>
+  state.cells.future.length > 0;

--- a/jbook/packages/local-client/src/state/undo-redo.test.ts
+++ b/jbook/packages/local-client/src/state/undo-redo.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { ActionCreators } from 'redux-undo';
+import { undoableCellsReducer } from './store';
+import {
+  deleteCell,
+  fetchCells,
+  insertCellAfter,
+  moveCell,
+  updateCell,
+} from './cells-slice';
+import { Cell } from './cell';
+import { UNDO_HISTORY_LIMIT } from '../constants';
+
+const cells: Cell[] = [
+  { id: 'a', type: 'code', content: 'show(1);' },
+  { id: 'b', type: 'text', content: '# hi' },
+];
+
+const makeStore = () => {
+  const store = configureStore({
+    reducer: { cells: undoableCellsReducer },
+  });
+  store.dispatch({ type: fetchCells.fulfilled.type, payload: cells });
+  return store;
+};
+
+const present = (store: ReturnType<typeof makeStore>) =>
+  store.getState().cells.present;
+const past = (store: ReturnType<typeof makeStore>) =>
+  store.getState().cells.past;
+
+describe('notebook undo/redo', () => {
+  it('loading the notebook is not undoable', () => {
+    const store = makeStore();
+    expect(past(store)).toHaveLength(0);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).order).toEqual(['a', 'b']);
+  });
+
+  it('undoes and redoes a content edit', () => {
+    const store = makeStore();
+    store.dispatch(updateCell('a', 'show(2);'));
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).data['a'].content).toBe('show(1);');
+
+    store.dispatch(ActionCreators.redo());
+    expect(present(store).data['a'].content).toBe('show(2);');
+  });
+
+  it('undo restores a deleted cell with its content and position', () => {
+    const store = makeStore();
+    store.dispatch(deleteCell('a'));
+    expect(present(store).order).toEqual(['b']);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).order).toEqual(['a', 'b']);
+    expect(present(store).data['a'].content).toBe('show(1);');
+  });
+
+  it('undo reverts a move', () => {
+    const store = makeStore();
+    store.dispatch(moveCell('b', 'up'));
+    expect(present(store).order).toEqual(['b', 'a']);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).order).toEqual(['a', 'b']);
+  });
+
+  it('groups a typing burst in one cell into a single history entry', () => {
+    const store = makeStore();
+    store.dispatch(updateCell('a', 's'));
+    store.dispatch(updateCell('a', 'sh'));
+    store.dispatch(updateCell('a', 'show(9);'));
+    expect(past(store)).toHaveLength(1);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).data['a'].content).toBe('show(1);');
+  });
+
+  it('starts a new history entry when editing a different cell', () => {
+    const store = makeStore();
+    store.dispatch(updateCell('a', 'show(2);'));
+    store.dispatch(updateCell('b', '# edited'));
+    expect(past(store)).toHaveLength(2);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).data['b'].content).toBe('# hi');
+    expect(present(store).data['a'].content).toBe('show(2);');
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).data['a'].content).toBe('show(1);');
+  });
+
+  it('a new edit clears the redo future', () => {
+    const store = makeStore();
+    store.dispatch(updateCell('a', 'show(2);'));
+    store.dispatch(ActionCreators.undo());
+    expect(store.getState().cells.future).toHaveLength(1);
+
+    store.dispatch(deleteCell('b'));
+    expect(store.getState().cells.future).toHaveLength(0);
+  });
+
+  it('caps history at UNDO_HISTORY_LIMIT entries', () => {
+    const store = makeStore();
+    for (let i = 0; i < UNDO_HISTORY_LIMIT + 10; i++) {
+      store.dispatch(insertCellAfter(null, 'code'));
+    }
+    // redux-undo's limit counts the present state as one of the history
+    // states, so past holds limit - 1 entries.
+    expect(past(store)).toHaveLength(UNDO_HISTORY_LIMIT - 1);
+  });
+});

--- a/jbook/packages/local-client/src/test-utils.tsx
+++ b/jbook/packages/local-client/src/test-utils.tsx
@@ -2,7 +2,8 @@ import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { ReactElement, ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import cellsReducer, { fetchCells } from './state/cells-slice';
+import { fetchCells } from './state/cells-slice';
+import { undoableCellsReducer } from './state/store';
 import bundlesReducer from './state/bundles-slice';
 import { Cell } from './state/cell';
 
@@ -10,7 +11,7 @@ import { Cell } from './state/cell';
 // don't fire network saves), optionally pre-seeded with cells.
 export const makeStore = (cells: Cell[] = []) => {
   const store = configureStore({
-    reducer: { cells: cellsReducer, bundles: bundlesReducer },
+    reducer: { cells: undoableCellsReducer, bundles: bundlesReducer },
   });
   if (cells.length > 0) {
     store.dispatch({ type: fetchCells.fulfilled.type, payload: cells });


### PR DESCRIPTION
## Summary

Implements TODO item 14 — the first P3 feature. The notebook gets full undo/redo: buttons in the UI, keyboard shortcuts, history depth limiting, keystroke grouping, and persistence of restored states.

### Design
- **`redux-undo` wraps the cells slice** at the store level (the option the TODO suggested). Undoable actions: update, delete, move, insert. The fetch/save lifecycle is filtered out so **undo can never rewind past the initially loaded notebook** — with `syncFilter: true`, which matters: without it, redux-undo's internal snapshot misses the filtered fetch and the first undo rewinds to an *empty* notebook (caught by the new tests on the first run).
- **Typing bursts group per cell**: consecutive `updateCell` actions to the same cell form one history entry (undo reverts the burst, not one character — the TODO's "don't track every keystroke"), and editing a different cell starts a new entry. This is deliberately finer than `groupByActionTypes`, which would merge edits across different cells into one entry.
- **History capped at 50 states** (`UNDO_HISTORY_LIMIT`, documented in constants.ts; redux-undo counts the present state toward the limit).
- **Undo/redo are persist triggers** — restoring an old state writes it to `notebook.js` like any other edit.
- **Shortcuts defer to text editors**: Ctrl/Cmd+Z, Ctrl+Y, Ctrl/Cmd+Shift+Z work at the notebook level, but stand down when focus is inside Monaco, the markdown editor, or any input — those own their local text-undo stacks and must not be hijacked.
- Consumers read the notebook through a new `selectCells` selector (`state.cells.present`); `selectCanUndo`/`selectCanRedo` drive the buttons' disabled states.
- `redux` returns as a devDependency: redux-undo's type declarations import from `'redux'`, which stopped resolving after the RTK migration removed the direct dep (manifested as `state.cells: unknown` everywhere).

### Tests (65 total now, all green)
14 new: history semantics (undo/redo of every edit type, per-cell grouping, future-clearing on new edits, limit accounting, load-not-undoable), persist-on-undo/redo through the middleware, and the bar component — disabled states, button clicks, all four shortcut variants, and the editor-focus guard.

## Verification (browser, against the built app served by the CLI)
- Bar renders with both buttons disabled on a fresh load
- Deleted a cell → undo button enabled → clicked → cell restored in the UI **and `notebook.js` on disk showed it restored** (persist-on-undo confirmed end to end)
- `Ctrl+Y` redid the delete; `Ctrl+Z` undid it again — both against the real DOM
- With focus inside the markdown editor, `Ctrl+Z` left the notebook untouched (guard confirmed live)