### PR TITLE
Add offline mode: self-hosted Monaco, offline indicator, cache controls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -201,11 +201,11 @@
 **Effort:** 1 week
 **Impact:** Full offline capability
 
-- [ ] Create service worker for caching unpkg responses
-- [ ] Cache frequently used packages (react, axios, etc.)
-- [ ] Add "Offline Mode" indicator in UI
-- [ ] Handle cache invalidation strategy
-- [ ] Add settings to clear cache
+- [x] ~~Service worker~~ Implemented without one (PR #21): the app shell is served locally, npm module responses were already cached in IndexedDB by the bundler, and the real offline blocker was Monaco loading from a CDN — now self-hosted (with the theme font, the app makes zero external requests)
+- [x] Cache frequently used packages — every fetched module is cached on first use and served from IndexedDB after (PR #21)
+- [x] Add "Offline Mode" indicator in UI (PR #21)
+- [x] Handle cache invalidation strategy — entries pin the first-fetched version until cleared; clearing refetches and picks up new versions (PR #21)
+- [x] Add a Clear-module-cache button with cleared-count feedback (PR #21)
 
 ---
 

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -1049,6 +1049,16 @@
         }
       }
     },
+    "node_modules/@fontsource/lato": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-5.3.0.tgz",
+      "integrity": "sha512-0WhF/4rhrw+ErIyneKvhHn2YAl+xf8GDtllgOgOzDmeaSlLQtjpChXaQOpWhG2BchQW0WJy2zLV12Hdg0ndOMw==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "5.15.4",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
@@ -3683,12 +3693,13 @@
       }
     },
     "node_modules/@types/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -3702,17 +3713,6 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
       }
     },
     "node_modules/@types/superagent": {
@@ -5902,9 +5902,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -9900,12 +9900,15 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.21.2.tgz",
-      "integrity": "sha512-jS51RLuzMaoJpYbu7F6TPuWpnWTLD4kjRW0+AZzcryvbxrTwhNy1KC9yboyKpgMTahpUbDUsuQULoo0GV1EPqg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
+      }
     },
     "node_modules/monaco-jsx-highlighter": {
       "version": "2.77.77",
@@ -10484,19 +10487,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/nx/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/nx/node_modules/minimatch": {
@@ -15066,6 +15056,7 @@
       "devDependencies": {
         "@babel/parser": "^7.26.0",
         "@babel/traverse": "^7.26.0",
+        "@fontsource/lato": "^5.3.0",
         "@fortawesome/fontawesome-free": "^5.15.1",
         "@monaco-editor/react": "^4.7.0",
         "@my-scrapbook/types": "^3.0.0",
@@ -15122,17 +15113,6 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/local-client/node_modules/monaco-editor": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
-      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "3.4.8",
-        "marked": "14.0.0"
-      }
     },
     "packages/local-client/node_modules/react-redux": {
       "version": "9.3.0",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@babel/parser": "^7.26.0",
     "@babel/traverse": "^7.26.0",
+    "@fontsource/lato": "^5.3.0",
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@monaco-editor/react": "^4.7.0",
     "@my-scrapbook/types": "^3.0.0",

--- a/jbook/packages/local-client/src/bundler/module-cache.test.ts
+++ b/jbook/packages/local-client/src/bundler/module-cache.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cache = vi.hoisted(() => ({
+  length: vi.fn(),
+  clear: vi.fn(),
+}));
+
+vi.mock('localforage', () => ({
+  default: {
+    createInstance: () => cache,
+  },
+}));
+
+import { clearModuleCache, moduleCacheSize } from './module-cache';
+
+describe('module cache', () => {
+  beforeEach(() => {
+    cache.length.mockReset();
+    cache.clear.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('reports its size', async () => {
+    cache.length.mockResolvedValue(7);
+    await expect(moduleCacheSize()).resolves.toBe(7);
+  });
+
+  it('clears all entries and reports how many were removed', async () => {
+    cache.length.mockResolvedValue(3);
+
+    await expect(clearModuleCache()).resolves.toBe(3);
+    expect(cache.clear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/jbook/packages/local-client/src/bundler/module-cache.ts
+++ b/jbook/packages/local-client/src/bundler/module-cache.ts
@@ -1,0 +1,20 @@
+import localForage from 'localforage';
+
+// Every npm module fetched from unpkg during bundling is cached here
+// (IndexedDB), keyed by URL. Cache hits skip the network entirely, which is
+// what makes bundling previously-used packages work offline. Entries are
+// pinned until cleared: 'react' resolves to whatever version unpkg served
+// when it was first fetched.
+export const moduleCache = localForage.createInstance({
+  name: 'filecache',
+});
+
+export const moduleCacheSize = () => moduleCache.length();
+
+// Returns the number of entries cleared. The next bundle refetches modules
+// from unpkg, picking up new package versions.
+export const clearModuleCache = async (): Promise<number> => {
+  const count = await moduleCache.length();
+  await moduleCache.clear();
+  return count;
+};

--- a/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
@@ -1,10 +1,6 @@
 import * as esbuild from 'esbuild-wasm';
 import axios from 'axios';
-import localForage from 'localforage';
-
-const fileCache = localForage.createInstance({
-  name: 'filecache',
-});
+import { moduleCache as fileCache } from '../module-cache';
 
 export const fetchPlugin = (inputCode: string) => {
   return {

--- a/jbook/packages/local-client/src/components/cell-list.css
+++ b/jbook/packages/local-client/src/components/cell-list.css
@@ -5,3 +5,15 @@
 .react-draggable-transparent-selection .cell-list {
   margin-bottom: 100vh;
 }
+
+.notebook-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 10px 0 10px;
+}
+
+.notebook-toolbar .undo-redo-bar {
+  padding: 0;
+}

--- a/jbook/packages/local-client/src/components/cell-list.tsx
+++ b/jbook/packages/local-client/src/components/cell-list.tsx
@@ -6,6 +6,7 @@ import CellListItem from "./cell-list-item";
 import AddCell from "./add-cell";
 import ErrorBoundary from "./error-boundary";
 import UndoRedoBar from "./undo-redo-bar";
+import OfflineStatus from "./offline-status";
 import { useActions } from "../hooks/use-actions";
 
 const CellList: React.FC = () => {
@@ -30,7 +31,10 @@ const CellList: React.FC = () => {
 
   return (
     <div className="cell-list">
-      <UndoRedoBar />
+      <div className="notebook-toolbar">
+        <OfflineStatus />
+        <UndoRedoBar />
+      </div>
       <AddCell forceVisible={cells.length === 0} previousCellId={null} />
       {renderedCells}
     </div>

--- a/jbook/packages/local-client/src/components/code-editor.tsx
+++ b/jbook/packages/local-client/src/components/code-editor.tsx
@@ -1,3 +1,4 @@
+import '../monaco-setup';
 import './code-editor.css';
 import './syntax.css';
 import { useRef } from 'react';

--- a/jbook/packages/local-client/src/components/offline-status.css
+++ b/jbook/packages/local-client/src/components/offline-status.css
@@ -1,0 +1,9 @@
+.offline-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.offline-status .tag {
+  height: auto;
+}

--- a/jbook/packages/local-client/src/components/offline-status.test.tsx
+++ b/jbook/packages/local-client/src/components/offline-status.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OfflineStatus from './offline-status';
+import { clearModuleCache } from '../bundler/module-cache';
+
+vi.mock('../bundler/module-cache', () => ({
+  clearModuleCache: vi.fn(),
+}));
+
+describe('OfflineStatus', () => {
+  beforeEach(() => {
+    vi.mocked(clearModuleCache).mockReset().mockResolvedValue(4);
+  });
+
+  it('shows no offline badge while online', () => {
+    render(<OfflineStatus />);
+    expect(screen.queryByText(/offline/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /clear module cache/i })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the offline badge when the connection drops and hides it on return', () => {
+    render(<OfflineStatus />);
+
+    fireEvent(window, new Event('offline'));
+    expect(
+      screen.getByText(/offline — cached packages still work/i)
+    ).toBeInTheDocument();
+
+    fireEvent(window, new Event('online'));
+    expect(screen.queryByText(/offline/i)).not.toBeInTheDocument();
+  });
+
+  it('clears the module cache and reports the count', async () => {
+    const user = userEvent.setup();
+    render(<OfflineStatus />);
+
+    await user.click(
+      screen.getByRole('button', { name: /clear module cache/i })
+    );
+
+    expect(clearModuleCache).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByText('Cleared 4 cached modules')
+    ).toBeInTheDocument();
+  });
+
+  it('uses singular wording for a single cleared module', async () => {
+    vi.mocked(clearModuleCache).mockResolvedValue(1);
+    const user = userEvent.setup();
+    render(<OfflineStatus />);
+
+    await user.click(
+      screen.getByRole('button', { name: /clear module cache/i })
+    );
+
+    expect(
+      await screen.findByText('Cleared 1 cached module')
+    ).toBeInTheDocument();
+  });
+});

--- a/jbook/packages/local-client/src/components/offline-status.tsx
+++ b/jbook/packages/local-client/src/components/offline-status.tsx
@@ -1,0 +1,65 @@
+import './offline-status.css';
+import { useEffect, useState } from 'react';
+import { clearModuleCache } from '../bundler/module-cache';
+
+// Everything the app needs at runtime is served locally or cached: the
+// editor and bundler are part of the build, and npm modules fetched from
+// unpkg are cached in IndexedDB. Offline, only imports of packages never
+// fetched before will fail — this badge tells the user which world they
+// are in, and the button empties the module cache so the next bundle picks
+// up fresh package versions.
+const OfflineStatus: React.FC = () => {
+  const [online, setOnline] = useState(() => navigator.onLine);
+  const [clearedCount, setClearedCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (clearedCount === null) {
+      return;
+    }
+    const timer = setTimeout(() => setClearedCount(null), 3000);
+    return () => clearTimeout(timer);
+  }, [clearedCount]);
+
+  const onClearCache = async () => {
+    const count = await clearModuleCache();
+    setClearedCount(count);
+  };
+
+  return (
+    <div className="offline-status">
+      {!online && (
+        <span
+          className="tag is-warning"
+          title="No network connection. Previously used npm packages are cached and keep working; imports of new packages will fail until you are back online."
+        >
+          Offline — cached packages still work
+        </span>
+      )}
+      {clearedCount !== null && (
+        <span className="tag is-info">
+          Cleared {clearedCount} cached module{clearedCount === 1 ? '' : 's'}
+        </span>
+      )}
+      <button
+        className="button is-small"
+        title="Empty the npm module cache; the next run refetches packages from unpkg and picks up new versions"
+        onClick={onClearCache}
+      >
+        Clear module cache
+      </button>
+    </div>
+  );
+};
+
+export default OfflineStatus;

--- a/jbook/packages/local-client/src/index.tsx
+++ b/jbook/packages/local-client/src/index.tsx
@@ -1,3 +1,9 @@
+// Self-hosted Lato replaces the Google Fonts @import that bulmaswatch's css
+// carries (stripped at build time in vite.config.ts) so the app has no
+// external requests at all.
+import "@fontsource/lato/300.css";
+import "@fontsource/lato/400.css";
+import "@fontsource/lato/700.css";
 import "bulmaswatch/superhero/bulmaswatch.min.css";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 import { createRoot } from "react-dom/client";

--- a/jbook/packages/local-client/src/monaco-setup.ts
+++ b/jbook/packages/local-client/src/monaco-setup.ts
@@ -1,0 +1,20 @@
+// Self-host Monaco: bundle the editor from the installed monaco-editor
+// package instead of @monaco-editor/react's default CDN loader, so the app
+// works fully offline. Vite's ?worker imports produce the web workers Monaco
+// needs; only the base editor worker and the typescript worker are included
+// since the notebook only edits JavaScript.
+import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
+import EditorWorker from 'monaco-editor/editor/editor.worker.js?worker';
+import TsWorker from 'monaco-editor/language/typescript/ts.worker.js?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string) {
+    if (label === 'typescript' || label === 'javascript') {
+      return new TsWorker();
+    }
+    return new EditorWorker();
+  },
+};
+
+loader.config({ monaco });

--- a/jbook/packages/local-client/vite.config.ts
+++ b/jbook/packages/local-client/vite.config.ts
@@ -2,7 +2,24 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      // bulmaswatch's theme css @imports the Lato font from Google Fonts —
+      // the one remaining external request. The font is self-hosted via
+      // @fontsource/lato instead, so the app is fully offline-capable.
+      name: 'strip-remote-font-import',
+      enforce: 'pre',
+      transform(code, id) {
+        if (id.includes('bulmaswatch') && id.endsWith('.css')) {
+          return code.replace(
+            /@import url\([^)]*fonts\.googleapis[^)]*\);?/g,
+            ''
+          );
+        }
+      },
+    },
+  ],
   test: {
     // State/plugin tests run in node; component tests opt into jsdom with a
     // `@vitest-environment jsdom` docblock.


### PR DESCRIPTION
## Summary

Implements TODO item 11 (offline mode) — **deliberately without the service worker the TODO suggested**. Reasoning: the app shell is served by the local server (available whenever the app runs at all), npm module responses were *already* cached in IndexedDB by the bundler's fetch plugin, and esbuild's wasm has shipped locally since #7. A service worker would have duplicated existing caching while fixing neither of the two real offline blockers this PR closes:

### 1. Monaco no longer loads from a CDN
Bundled from the installed `monaco-editor` package (`loader.config({ monaco })` + Vite `?worker` imports via the package's exports-map subpaths). This was the follow-up flagged back in #8. Also deduped a nested `monaco-editor@0.21.2` that monaco-jsx-highlighter had pulled in alongside the hoisted 0.56 (broke type identity).

### 2. The theme font no longer loads from Google Fonts
Found by sweeping the network log for external requests during verification: bulmaswatch's CSS `@import`s Lato from `fonts.googleapis.com`. A tiny build-time transform strips the import and `@fontsource/lato` self-hosts the font. **A warm-cache page load now makes zero requests beyond localhost** — measured, not assumed.

### Offline UX (the TODO's remaining sub-items)
- **Offline badge** in a new notebook toolbar (next to undo/redo), driven by `online`/`offline` events: "Offline — cached packages still work". Cached modules bundle fine offline; only imports never fetched before need network.
- **Clear-module-cache button** with cleared-count feedback. This is also the cache-invalidation story, now documented in `module-cache.ts`: entries pin whatever version unpkg served on first fetch until cleared; clearing makes the next bundle refetch and pick up new versions.
- The bundler's cache moves to a shared `module-cache.ts` consumed by both the fetch plugin and the UI.

### Trade-off to review
`build/` grows to **~32 MB unpacked** (Monaco in the main chunk + a 6.7 MB TS worker; the json/css/html workers are lazily referenced and never fetched by this JS-only app, but they ship in the tarball). Slimming via `editor.api` feature-imports is a possible follow-up if the size bothers you.

## Verification

**Tests**: 6 new (cache size/clear semantics, badge appear/disappear, feedback with pluralization) — 81 total across both packages, green.

**Browser, against the served build:**
- Cold cache: axios cell bundles from unpkg (9 fetches), Monaco workers load from **localhost** — zero jsdelivr/CDN traffic
- Warm cache reload: preview renders with **zero external requests of any kind** (the full offline claim, measured via the resource log)
- Offline badge appears on the `offline` event, disappears on `online`
- Clear cache: IndexedDB entries 9 → 0 (verified directly), next load refetches all 9 from unpkg