### PR TITLE
Prepare the 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 3.1.0 — 2026-07-28
+
+### Added
+- **Undo/redo for the notebook.** Cell edits, deletes, moves, and inserts can be undone and redone via toolbar buttons or keyboard shortcuts (Ctrl/Cmd+Z, Ctrl+Y, Ctrl/Cmd+Shift+Z). Typing bursts in a cell group into a single undo step, history is capped at 50 states, and the shortcuts stand down while you're typing inside the code or markdown editors, which keep their own text-level undo. Undone and redone states are saved to `notebook.js` like any other edit.
+- **Full offline mode.** The editor (Monaco) and the Lato UI font are now bundled with the app instead of loading from CDNs — a warm page load makes zero external requests. npm modules fetched from unpkg were already cached in IndexedDB; an offline badge now tells you when you've lost network ("cached packages still work"), and a **Clear module cache** button empties the cache so the next run picks up fresh package versions.
+
+### Fixed
+- The preview pane no longer throws if a cell is removed in the brief window between rendering and executing its bundle (an uncancelled timer dereferenced a null iframe).
+
+## 3.0.1 — 2026-07-27
+
+- npm packaging metadata: current README on the npm page, repository/homepage/bugs links, description and keywords. No code changes.
+
+## 3.0.0 — 2026-07-27
+
+First release after the repository modernization; versions 2.x are deprecated (they can no longer render React components — they relied on `ReactDOM.render`, which current React, served from unpkg, has removed).
+
+- Rebuilt on Vite, TypeScript 5, React 18, and Redux Toolkit (previously Create React App, TS 4.1, React 17, hand-written Redux).
+- The in-browser bundler upgraded to current esbuild-wasm and ships its own wasm binary — bundling no longer fetches the compiler from a CDN.
+- Editor stack upgraded: Monaco 0.56, markdown editor v4, Babel-based JSX highlighting.
+- Each cell renders inside an error boundary: a crash shows an error message with a Reset button instead of taking down the whole notebook.
+- Cell IDs are UUIDs (previously 5-character random strings with realistic collision odds).
+- The save API validates its input (zod) and answers 400 with details for malformed payloads; a corrupted `notebook.js` returns a 500 instead of crashing the server, and the JSON body limit is an explicit 5 MB.
+- Dependency security updates throughout (axios 1.x, immer 10, http-proxy-middleware 3, Express 4.22).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ npx my-scrapbook serve
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
 ![The install folder showing the saved notebook.js file](docs/images/notebook-file.png)
 
+## What's new in 3.1
+
+- **Undo/redo**: toolbar buttons plus Ctrl/Cmd+Z, Ctrl+Y, and Ctrl/Cmd+Shift+Z. Typing bursts undo as one step; the shortcuts stay out of the way while you're typing inside an editor.
+- **Works fully offline**: the editor and fonts are bundled with the app, and npm packages you've used before are served from a local cache — a badge tells you when you're offline, and a button clears the module cache to pick up fresh package versions.
+
 ## What's new in 3.0
 
 - Rebuilt on a modern toolchain: Vite, TypeScript 5, React 18, and Redux Toolkit.
@@ -142,6 +147,10 @@ npm test
 ```
 
 To work on the browser app with hot reload, run `npm start` in `jbook/packages/local-client` (it serves on port 3000; run the CLI's `serve` command alongside it to have a real API to talk to). Each package's README has more detail, and CI runs the builds and tests on every pull request.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the release history.
 
 ## Roadmap
 

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14528,7 +14528,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15051,7 +15051,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/parser": "^7.26.0",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -31,6 +31,11 @@ npx my-scrapbook serve
 - If you want to start a new notebook and don't care about the saved work from your previous session, delete the **notebook.js** file in the same directory before starting My Scrapbook again.
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
 
+## What's new in 3.1
+
+- **Undo/redo**: toolbar buttons plus Ctrl/Cmd+Z, Ctrl+Y, and Ctrl/Cmd+Shift+Z. Typing bursts undo as one step; the shortcuts stay out of the way while you're typing inside an editor.
+- **Works fully offline**: the editor and fonts are bundled with the app, and npm packages you've used before are served from a local cache — a badge tells you when you're offline, and a button clears the module cache to pick up fresh package versions.
+
 ## What's new in 3.0
 
 - Rebuilt on a modern toolchain: Vite, TypeScript 5, React 18, and Redux Toolkit.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for **3.1.0** — shipping undo/redo and offline mode to npm users (currently on 3.0.1).

### Version strategy
- **`my-scrapbook` 3.0.1 → 3.1.0** and **`@my-scrapbook/local-client` 3.0.0 → 3.1.0** — these carry everything since the last publish: undo/redo (#20), offline mode (#21), and the preview unmount fix (#19)
- **`local-api` and `types` are deliberately not bumped**: unchanged since their 3.0.0 publishes, and the cli's `^3.0.0` ranges already resolve to them — no wasteful republishes (or extra 2FA rounds)
- `lerna.json`'s version marker syncs to 3.1.0

### Docs
- New **CHANGELOG.md** covering 3.1.0 / 3.0.1 / 3.0.0 (including the 2.x deprecation context), linked from the root README
- **"What's new in 3.1"** sections on the root README and the cli README — the latter is what npmjs.com renders, so the package page will be current the moment 3.1.0 publishes

### Verified from a clean install
- `npm ci` → all three builds green → **81 tests green** → CLI smoke test serves the app and API
- Tarball dry-runs: `local-client` **9.2 MB** (33 MB unpacked — Monaco + esbuild wasm bundled, the price of full offline), `my-scrapbook` 588 kB

## Publishing (after merge, in this order)
```
cd ~/repos/code-editor && git pull && cd jbook && npm ci
npm publish -w @my-scrapbook/local-client
npm publish -w my-scrapbook
```
Each publish needs the usual browser approval — wait for the `+ package@3.1.0` line. Then tag:
```
git tag v3.1.0 && git push origin v3.1.0
```