### PR TITLE
Prepare the 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.2.0 — 2026-07-28
 
 ### Changed
 - **Notebook UI redesigned on the Modernist design system.** Light ground, flat surfaces, zero corner radius, Archivo type, and a single red accent replace the dark Bulmaswatch "Superhero" theme. Functionally the app is unchanged; the chrome is new:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npx my-scrapbook serve
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
 ![The install folder showing the saved notebook.js file](docs/images/notebook-file.png)
 
+## What's new in 3.2
+
+- **Redesigned UI.** A light, flat look with a single red accent replaces the old dark theme: a sticky header with the notebook's save state, undo/redo, **Clear cache**, and **Run all**; a collapsible "How this works" guide; a start screen for empty notebooks; numbered cell headers with live bundle timing; and always-visible add-cell rails. Same features, new chrome.
+
 ## What's new in 3.1
 
 - **Undo/redo**: toolbar buttons plus Ctrl/Cmd+Z, Ctrl+Y, and Ctrl/Cmd+Shift+Z. Typing bursts undo as one step; the shortcuts stay out of the way while you're typing inside an editor.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.1.0"
+  "version": "3.2.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14520,7 +14520,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15043,7 +15043,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/parser": "^7.26.0",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -31,6 +31,10 @@ npx my-scrapbook serve
 - If you want to start a new notebook and don't care about the saved work from your previous session, delete the **notebook.js** file in the same directory before starting My Scrapbook again.
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
 
+## What's new in 3.2
+
+- **Redesigned UI.** A light, flat look with a single red accent replaces the old dark theme: a sticky header with the notebook's save state, undo/redo, **Clear cache**, and **Run all**; a collapsible "How this works" guide; a start screen for empty notebooks; numbered cell headers with live bundle timing; and always-visible add-cell rails. Same features, new chrome.
+
 ## What's new in 3.1
 
 - **Undo/redo**: toolbar buttons plus Ctrl/Cmd+Z, Ctrl+Y, and Ctrl/Cmd+Shift+Z. Typing bursts undo as one step; the shortcuts stay out of the way while you're typing inside an editor.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release prep for **3.2.0** — shipping the Modernist UI redesign to npm, and bringing the published package in line with the screenshots already on the npm page.

- `my-scrapbook` and `@my-scrapbook/local-client` → 3.2.0; `local-api`/`types` stay at 3.0.0 (unchanged, `^3.0.0` ranges cover them)
- CHANGELOG's *Unreleased* section becomes **3.2.0 — 2026-07-28** (content was already written with the redesign)
- "What's new in 3.2" added to both READMEs (the cli one lands on the npm page with this publish)

## Verified from a clean install
- `npm ci` → all builds green → **81 tests green** → CLI smoke test serves the app
- Tarballs: `local-client` **7.9 MB** (down from 9.2 — dropping bulmaswatch and Font Awesome outweighed the self-hosted Archivo), `my-scrapbook` 588 kB

## Publishing (after merge, in this order)
```
cd ~/repos/code-editor && git pull && cd jbook && npm ci
npm publish -w @my-scrapbook/local-client
npm publish -w my-scrapbook
```
Browser approval per publish; wait for each `+ package@3.2.0` line — and note the **second command targets `my-scrapbook`**, not local-client again. Then:
```
git tag v3.2.0 && git push origin v3.2.0
```