### PR TITLE
CLI improvements for npm users + 3.3.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.3.0 — 2026-08-02
 
 ### Added
 - **Markdown export.** `npx my-scrapbook export` converts a notebook to a plain markdown file: text cells come through as-is and code cells become fenced ```` ```jsx ```` blocks (the fence grows automatically if a cell itself contains backtick runs). `-o` picks the output path, which defaults to the notebook's name with `.md`; refuses to overwrite the notebook itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Markdown export.** `npx my-scrapbook export` converts a notebook to a plain markdown file: text cells come through as-is and code cells become fenced ```` ```jsx ```` blocks (the fence grows automatically if a cell itself contains backtick runs). `-o` picks the output path, which defaults to the notebook's name with `.md`; refuses to overwrite the notebook itself.
+- `my-scrapbook --version` reports the installed version, and the package declares `engines.node >= 18` so npm warns on unsupported Node versions at install time.
+
+### Changed
+- `serve` opens your browser automatically once the server is up. Pass `--no-open` to just print the URL like before.
+- `serve` is now the default command: a bare `npx my-scrapbook` opens `notebook.js`.
+
 ## 3.2.0 — 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ npm i my-scrapbook
 - In the same folder you install My Scrapbook, open up a terminal session and run:
 
 ```
-npx my-scrapbook serve
+npx my-scrapbook
 ```
-- **Ctrl + click** on the link in the terminal that says **http://localhost:4005**
+- Your browser opens to the notebook automatically. (Prefer to open it yourself? Pass `--no-open` and **Ctrl + click** the **http://localhost:4005** link in the terminal.)
+- Want a different port or a named notebook? Both are options of the `serve` command (running `npx my-scrapbook` alone is shorthand for `npx my-scrapbook serve notebook.js`):
+
+```
+npx my-scrapbook serve mynotes.js -p 4200
+```
 - Click **Code cell** or **Text cell** on the start screen to create your first cell. After that, use the **+ Code** / **+ Text** buttons between cells to add more.
   ![The start screen with Code cell and Text cell buttons](docs/images/blank.png)
   ![A text cell open in the markdown editor above a code cell](docs/images/editing.png)
@@ -31,6 +36,20 @@ npx my-scrapbook serve
 - If you want to start a new notebook and don't care about the saved work from your previous session, delete the **notebook.js** file in the same directory before starting My Scrapbook again. (Or you could leave the **notebook.js** and click the **X** button on all your previous work once the IDE is loaded into the browser.)
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
 ![The install folder showing the saved notebook.js file](docs/images/notebook-file.png)
+
+## Export a notebook to Markdown
+
+- To turn a notebook into a plain markdown file you can share anywhere (GitHub, a blog, a teammate without My Scrapbook), run:
+
+```
+npx my-scrapbook export
+```
+- This writes **notebook.md** next to **notebook.js**: text cells come through as-is, and code cells become fenced ` ```jsx ` blocks.
+- Exporting a named notebook to a specific file works too:
+
+```
+npx my-scrapbook export mynotes.js -o docs/mynotes.md
+```
 
 ## What's new in 3.2
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.3
+
+- **Markdown export.** `npx my-scrapbook export` turns a notebook into a plain markdown file you can share anywhere — see "Export a notebook to Markdown" above.
+- **Smoother start.** A bare `npx my-scrapbook` now opens `notebook.js` and launches your browser automatically (pass `--no-open` to opt out). The CLI also reports its version with `--version` and warns at install time on Node versions older than 18.
+
 ## What's new in 3.2
 
 - **Redesigned UI.** A light, flat look with a single red accent replaces the old dark theme: a sticky header with the notebook's save state, undo/redo, **Clear cache**, and **Run all**; a collapsible "How this works" guide; a start screen for empty notebooks; numbered cell headers with live bundle timing; and always-visible add-cell rails. Same features, new chrome.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.2.0"
+  "version": "3.3.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14520,7 +14520,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14531,9 +14531,15 @@
         "my-scrapbook": "dist/index.js"
       },
       "devDependencies": {
+        "@my-scrapbook/types": "^3.0.0",
         "@types/node": "^20.19.0",
+        "@vitest/coverage-v8": "^3.2.7",
         "esbuild": "^0.25.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/cli/node_modules/@esbuild/aix-ppc64": {

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -20,9 +20,14 @@ npm i my-scrapbook
 - In the same folder you install My Scrapbook, open up a terminal session and run:
 
 ```
-npx my-scrapbook serve
+npx my-scrapbook
 ```
-- **Ctrl + click** on the link in the terminal that says **http://localhost:4005**
+- Your browser opens to the notebook automatically. (Prefer to open it yourself? Pass `--no-open` and **Ctrl + click** the **http://localhost:4005** link in the terminal.)
+- Want a different port or a named notebook? Both are options of the `serve` command (running `npx my-scrapbook` alone is shorthand for `npx my-scrapbook serve notebook.js`):
+
+```
+npx my-scrapbook serve mynotes.js -p 4200
+```
 - Click **Code cell** or **Text cell** on the start screen to create your first cell. After that, use the **+ Code** / **+ Text** buttons between cells to add more.
   ![The start screen with Code cell and Text cell buttons](https://raw.githubusercontent.com/dannysarco/code-editor/live/docs/images/blank.png)
   ![A text cell open in the markdown editor above a code cell](https://raw.githubusercontent.com/dannysarco/code-editor/live/docs/images/editing.png)
@@ -30,6 +35,20 @@ npx my-scrapbook serve
 - Next time you run the application using the same command, it will open to your previous **notebook.js** file.
 - If you want to start a new notebook and don't care about the saved work from your previous session, delete the **notebook.js** file in the same directory before starting My Scrapbook again.
 - If you want to keep your previous work and start a new notebook, rename or move the **notebook.js** file in the same directory before starting My Scrapbook again.
+
+## Export a notebook to Markdown
+
+- To turn a notebook into a plain markdown file you can share anywhere (GitHub, a blog, a teammate without My Scrapbook), run:
+
+```
+npx my-scrapbook export
+```
+- This writes **notebook.md** next to **notebook.js**: text cells come through as-is, and code cells become fenced ` ```jsx ` blocks.
+- Exporting a named notebook to a specific file works too:
+
+```
+npx my-scrapbook export mynotes.js -o docs/mynotes.md
+```
 
 ## What's new in 3.2
 

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -50,6 +50,11 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.3
+
+- **Markdown export.** `npx my-scrapbook export` turns a notebook into a plain markdown file you can share anywhere — see "Export a notebook to Markdown" above.
+- **Smoother start.** A bare `npx my-scrapbook` now opens `notebook.js` and launches your browser automatically (pass `--no-open` to opt out). The CLI also reports its version with `--version` and warns at install time on Node versions older than 18.
+
 ## What's new in 3.2
 
 - **Redesigned UI.** A light, flat look with a single red accent replaces the old dark theme: a sticky header with the notebook's save state, undo/redo, **Clear cache**, and **Run all**; a collapsible "How this works" guide; a start screen for empty notebooks; numbered cell headers with live bundle timing; and always-visible add-cell rails. Same features, new chrome.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -12,6 +12,9 @@
   ],
   "author": "Danny Sarco",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "bin": {
     "my-scrapbook": "dist/index.js"
   },
@@ -23,6 +26,8 @@
   ],
   "scripts": {
     "start": "tsc --watch --preserveWatchOutput",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "esbuild src/index.ts --platform=node --outfile=dist/index.js --bundle --minify --define:process.env.NODE_ENV=\\\"production\\\""
   },
   "dependencies": {
@@ -31,9 +36,12 @@
     "commander": "^7.0.0"
   },
   "devDependencies": {
+    "@my-scrapbook/types": "^3.0.0",
     "@types/node": "^20.19.0",
+    "@vitest/coverage-v8": "^3.2.7",
     "esbuild": "^0.25.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.7"
   },
   "repository": {
     "type": "git",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/cli/src/commands/export.ts
+++ b/jbook/packages/cli/src/commands/export.ts
@@ -1,0 +1,51 @@
+import fs from "fs/promises";
+import path from "path";
+import { Command } from "commander";
+import { cellsToMarkdown, parseNotebook } from "../markdown";
+
+export const exportCommand = new Command()
+  .command("export [filename]")
+  .description("Convert a notebook to a markdown file (default: notebook.js)")
+  .option(
+    "-o, --out <file>",
+    "file to write the markdown to (default: the notebook name with .md)"
+  )
+  .action(async (filename = "notebook.js", options: { out?: string }) => {
+    const inputPath = path.resolve(process.cwd(), filename);
+    const outFile =
+      options.out ?? filename.replace(/\.[^./\\]*$/, "") + ".md";
+    const outPath = path.resolve(process.cwd(), outFile);
+
+    if (outPath === inputPath) {
+      console.error(
+        `The output file would overwrite the notebook itself (${filename}). Pick a different -o path.`
+      );
+      process.exit(1);
+    }
+
+    let raw: string;
+    try {
+      raw = await fs.readFile(inputPath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        console.error(
+          `No notebook found at ${filename}. Run "my-scrapbook serve ${filename}" to create one.`
+        );
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Could not read ${filename}: ${message}`);
+      }
+      process.exit(1);
+    }
+
+    try {
+      const cells = parseNotebook(raw);
+      await fs.writeFile(outPath, cellsToMarkdown(cells), "utf-8");
+      console.log(`Exported ${filename} to ${outFile}.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Could not export ${filename}: ${message}`);
+      process.exit(1);
+    }
+  });

--- a/jbook/packages/cli/src/commands/serve.ts
+++ b/jbook/packages/cli/src/commands/serve.ts
@@ -1,37 +1,46 @@
 import path from "path";
 import { Command } from "commander";
 import { serve } from "@my-scrapbook/local-api";
+import { openBrowser } from "../open-browser";
 
 const isProduction = process.env.NODE_ENV === "production";
 
 export const serveCommand = new Command()
   .command("serve [filename]")
-  .description("Open a file for editing")
+  .description("Open a notebook for editing (default: notebook.js)")
   .option("-p, --port <number>", "port to run server on", "4005")
-  .action(async (filename = "notebook.js", options: { port: string }) => {
-    try {
-      const dir = path.join(process.cwd(), path.dirname(filename));
-      await serve(
-        parseInt(options.port),
-        path.basename(filename),
-        dir,
-        !isProduction
-      );
-      console.log(
-        `Opened ${filename}. Navigate to http://localhost:${options.port} to edit the file.`
-      );
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "EADDRINUSE") {
-        console.error(
-          `Port ${options.port} is already in use. Pick another with: my-scrapbook serve ${filename} -p <port>`
+  .option("--no-open", "don't open the browser automatically")
+  .action(
+    async (
+      filename = "notebook.js",
+      options: { port: string; open: boolean }
+    ) => {
+      try {
+        const dir = path.join(process.cwd(), path.dirname(filename));
+        await serve(
+          parseInt(options.port),
+          path.basename(filename),
+          dir,
+          !isProduction
         );
-      } else {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(
-          `Failed to open ${filename} on port ${options.port}: ${message}`
-        );
+        const url = `http://localhost:${options.port}`;
+        console.log(`Opened ${filename}. Edit it at ${url}`);
+        if (options.open) {
+          openBrowser(url);
+        }
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EADDRINUSE") {
+          console.error(
+            `Port ${options.port} is already in use. Pick another with: my-scrapbook serve ${filename} -p <port>`
+          );
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(
+            `Failed to open ${filename} on port ${options.port}: ${message}`
+          );
+        }
+        process.exit(1);
       }
-      process.exit(1);
     }
-  });
+  );

--- a/jbook/packages/cli/src/index.ts
+++ b/jbook/packages/cli/src/index.ts
@@ -1,7 +1,21 @@
 #!/usr/bin/env node
 import { program } from 'commander';
 import { serveCommand } from './commands/serve';
+import { exportCommand } from './commands/export';
 
-program.addCommand(serveCommand);
+// Resolved at runtime relative to dist/index.js (esbuild inlines it into the
+// published bundle), so the reported version always matches the package.
+const { version } = require('../package.json') as { version: string };
+
+program
+  .name('my-scrapbook')
+  .description(
+    'An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live'
+  )
+  .version(version);
+
+// serve is the default so a bare `npx my-scrapbook` opens the notebook.
+program.addCommand(serveCommand, { isDefault: true });
+program.addCommand(exportCommand);
 
 program.parse(process.argv);

--- a/jbook/packages/cli/src/markdown.test.ts
+++ b/jbook/packages/cli/src/markdown.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Cell } from '@my-scrapbook/types';
+import { cellsToMarkdown, parseNotebook } from './markdown';
+
+const cell = (type: Cell['type'], content: string, id = 'x'): Cell => ({
+  id,
+  type,
+  content,
+});
+
+describe('parseNotebook', () => {
+  it('parses a valid notebook file', () => {
+    const raw = JSON.stringify([
+      cell('text', '# Hello'),
+      cell('code', 'show(1);'),
+    ]);
+    expect(parseNotebook(raw)).toHaveLength(2);
+  });
+
+  it('ignores extra fields on cells', () => {
+    const raw = JSON.stringify([
+      { id: 'a', type: 'code', content: 'show(1);', futureField: true },
+    ]);
+    expect(parseNotebook(raw)).toHaveLength(1);
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => parseNotebook('const x = 1;')).toThrow('not valid JSON');
+  });
+
+  it('rejects JSON that is not an array', () => {
+    expect(() => parseNotebook('{"cells": []}')).toThrow('array of cells');
+  });
+
+  it('rejects entries that are not cells', () => {
+    expect(() => parseNotebook('[{"type": "wat", "content": ""}]')).toThrow(
+      'cell 1 is not a code or text cell'
+    );
+    expect(() => parseNotebook('[{"type": "code", "content": 42}]')).toThrow(
+      'cell 1 is not a code or text cell'
+    );
+    expect(() => parseNotebook('["nope"]')).toThrow(
+      'cell 1 is not a code or text cell'
+    );
+  });
+});
+
+describe('cellsToMarkdown', () => {
+  it('emits text cells verbatim and code cells fenced', () => {
+    const md = cellsToMarkdown([
+      cell('text', '# Notes'),
+      cell('code', "show('hi');"),
+    ]);
+    expect(md).toBe("# Notes\n\n```jsx\nshow('hi');\n```\n");
+  });
+
+  it('trims trailing whitespace so cells are separated by one blank line', () => {
+    const md = cellsToMarkdown([
+      cell('text', '# Notes\n\n\n'),
+      cell('text', 'Body'),
+    ]);
+    expect(md).toBe('# Notes\n\nBody\n');
+  });
+
+  it('lengthens the fence when code contains backtick runs', () => {
+    const md = cellsToMarkdown([cell('code', 'const md = `\n```js\n`;')]);
+    expect(md.startsWith('````jsx\n')).toBe(true);
+    expect(md.endsWith('\n````\n')).toBe(true);
+  });
+
+  it('handles an empty notebook', () => {
+    expect(cellsToMarkdown([])).toBe('\n');
+  });
+});

--- a/jbook/packages/cli/src/markdown.ts
+++ b/jbook/packages/cli/src/markdown.ts
@@ -1,0 +1,53 @@
+import { Cell } from "@my-scrapbook/types";
+
+// Parses the raw contents of a notebook file, throwing a descriptive error if
+// the file isn't a My Scrapbook notebook. Kept intentionally lenient: extra
+// fields are ignored so future notebook versions still export.
+export const parseNotebook = (raw: string): Cell[] => {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error("the file is not valid JSON");
+  }
+
+  if (!Array.isArray(data)) {
+    throw new Error("expected a JSON array of cells");
+  }
+
+  data.forEach((cell, i) => {
+    const ok =
+      cell !== null &&
+      typeof cell === "object" &&
+      (cell.type === "code" || cell.type === "text") &&
+      typeof cell.content === "string";
+    if (!ok) {
+      throw new Error(`cell ${i + 1} is not a code or text cell`);
+    }
+  });
+
+  return data as Cell[];
+};
+
+// A code cell may itself contain backtick runs (template literals, markdown
+// examples); the fence must be longer than any run inside it.
+const fenceFor = (content: string): string => {
+  const longestRun = (content.match(/`+/g) ?? []).reduce(
+    (max, run) => Math.max(max, run.length),
+    0
+  );
+  return "`".repeat(Math.max(3, longestRun + 1));
+};
+
+export const cellsToMarkdown = (cells: Cell[]): string => {
+  const blocks = cells.map((cell) => {
+    const content = cell.content.trimEnd();
+    if (cell.type === "text") {
+      return content;
+    }
+    const fence = fenceFor(content);
+    return `${fence}jsx\n${content}\n${fence}`;
+  });
+
+  return blocks.join("\n\n") + "\n";
+};

--- a/jbook/packages/cli/src/open-browser.ts
+++ b/jbook/packages/cli/src/open-browser.ts
@@ -1,0 +1,25 @@
+import { spawn } from "child_process";
+
+// Best-effort: if the platform launcher is missing or fails, the URL is
+// already printed in the terminal, so errors are deliberately swallowed.
+export const openBrowser = (url: string) => {
+  let cmd: string;
+  let args: string[];
+
+  if (process.platform === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else if (process.platform === "win32") {
+    // The empty string is the window title `start` expects as its first
+    // quoted argument; without it the URL would be consumed as the title.
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+
+  spawn(cmd, args, { stdio: "ignore", detached: true })
+    .on("error", () => {})
+    .unref();
+};

--- a/jbook/packages/cli/tsconfig.json
+++ b/jbook/packages/cli/tsconfig.json
@@ -66,5 +66,7 @@
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/jbook/packages/cli/vitest.config.ts
+++ b/jbook/packages/cli/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      include: ['src/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Improves the first-run and everyday experience for people installing `my-scrapbook` from npm, and preps the 3.3.0 release.

### CLI improvements
- **`serve` opens the browser automatically** once the server is up, via a dependency-free platform helper (`open`/`start`/`xdg-open`); `--no-open` opts out and failures silently fall back to the printed URL.
- **`serve` is the default command** — a bare `npx my-scrapbook` opens `notebook.js`. The program also gained a name, description, and `--version` (read from package.json; esbuild inlines it into the published bundle).
- **New `export` command**: `npx my-scrapbook export [file] [-o out.md]` converts a notebook to plain markdown — text cells verbatim, code cells as fenced `jsx` blocks whose fences lengthen past any backtick runs in the code. Output defaults to the notebook name with `.md`; refuses to overwrite the notebook itself; specific errors for missing files, invalid JSON, and non-notebook content.
- **`engines.node >= 18`** so npm warns at install time instead of failing cryptically at runtime.

### Tests & docs
- The cli package now has a vitest suite (9 tests over notebook parsing and markdown conversion) wired into the root `npm test`; tsconfig excludes tests from the published build, matching local-api.
- Both READMEs lead with `npx my-scrapbook`, document the export command, and gain "What's new in 3.3" sections; CHANGELOG has the 3.3.0 entry.

### Release prep
- `my-scrapbook` → 3.3.0, `lerna.json` synced. local-client stays 3.2.0, local-api/types stay 3.0.0 (unchanged, covered by `^3.x` ranges).

## Verification
- Full workspace suite green: cli 9, local-api, local-client 71.
- Production bundle rebuilt and smoke-tested directly: `--version` reports 3.3.0, bare default serve works (`/cells` + app HTML return correctly), `EADDRINUSE` message intact, and every export path (happy, missing file, self-overwrite guard, invalid JSON) behaves.
- `npm pack --dry-run`: tarball still ships only `dist/index.js`, package.json, and the README.

Publishing to npm after merge needs the browser 2FA step.