### PR TITLE
Capture console output in the preview + fix the racy iframe code handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Console output in the preview.** `console.log`/`info`/`warn`/`error`/`debug` calls in cell code now show up in a console panel under the preview pane: objects are serialized (cycles become `[Circular]`), warnings and errors are tinted, the panel keeps the newest 200 entries, auto-scrolls, and has a **Clear** button. Runtime errors still render in the preview and now land in the console too.
+
+### Fixed
+- The preview could silently render nothing: the bundled code was posted into the iframe on a fixed 50 ms timer, so it was lost whenever the document hadn't installed its message listener yet — and the iframe loaded twice (JSX attribute plus effect), so a second load could wipe output that had already rendered. The iframe document now posts a `ready` signal once its listener is installed, and the parent posts the code exactly once, on that signal.
+
 ## 3.3.0 — 2026-08-02
 
 ### Added

--- a/jbook/packages/local-client/src/components/preview.css
+++ b/jbook/packages/local-client/src/components/preview.css
@@ -2,11 +2,14 @@
   position: relative;
   height: 100%;
   background: #ffffff;
+  display: flex;
+  flex-direction: column;
 }
 
 .preview-wrapper iframe {
   display: block;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   border: 0;
 }
@@ -22,12 +25,75 @@
   word-break: break-word;
 }
 
-.react-draggable-transparent-selection .preview-wrapper:after {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  opacity: 0;
+.preview-console {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  max-height: 45%;
+  border-top: 1px solid var(--color-divider);
+  background: var(--color-neutral-100);
+}
+
+.preview-console-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: none;
+  padding: 4px 12px;
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+
+.preview-console-title {
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
+.preview-console-clear {
+  border: 0;
+  padding: 2px 4px;
+  background: none;
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-neutral-600);
+}
+
+.preview-console-clear:hover {
+  color: var(--color-accent-600);
+}
+
+.preview-console-body {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.preview-console-entry {
+  padding: 1px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-neutral-900);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.preview-console-debug {
+  color: var(--color-neutral-500);
+}
+
+.preview-console-warn {
+  color: var(--color-accent-600);
+  background: var(--color-accent-100);
+}
+
+.preview-console-error {
+  color: var(--color-accent-700);
+  background: var(--color-accent-100);
 }

--- a/jbook/packages/local-client/src/components/preview.test.tsx
+++ b/jbook/packages/local-client/src/components/preview.test.tsx
@@ -1,18 +1,26 @@
 /** @vitest-environment jsdom */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
 import Preview from './preview';
-import { PREVIEW_EXECUTE_DELAY_MS } from '../constants';
+import { MAX_CONSOLE_ENTRIES } from '../constants';
+
+// Delivers a message event the way the iframe document would: same shape,
+// with event.source set to the sending window.
+const postIframeMessage = (source: Window | null, data: unknown) => {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data, source }));
+  });
+};
+
+const postConsoleMessage = (
+  source: Window | null,
+  level: string,
+  text: string
+) => {
+  postIframeMessage(source, { source: 'preview-console', level, text });
+};
 
 describe('Preview', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it('renders a sandboxed iframe whose document handles runtime errors', () => {
     render(<Preview code="console.log(1);" err="" />);
 
@@ -20,9 +28,27 @@ describe('Preview', () => {
     expect(iframe).toHaveAttribute('sandbox', 'allow-scripts');
     expect(iframe.getAttribute('srcdoc')).toContain('Runtime Error');
     expect(iframe.getAttribute('srcdoc')).toContain("addEventListener('message'");
+    expect(iframe.getAttribute('srcdoc')).toContain('preview-ready');
   });
 
-  it('posts the bundled code into the iframe after the settle delay', () => {
+  it('posts the bundled code only once the iframe document reports ready', () => {
+    const { container } = render(<Preview code="show(42);" err="" />);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const postMessage = vi.fn();
+    const contentWindow = { postMessage } as unknown as Window;
+    Object.defineProperty(iframe, 'contentWindow', { value: contentWindow });
+
+    expect(postMessage).not.toHaveBeenCalled();
+
+    postIframeMessage(contentWindow, { source: 'preview-ready' });
+    expect(postMessage).toHaveBeenCalledWith('show(42);', '*');
+
+    // A second ready from the same document must not re-execute stale code.
+    postIframeMessage(contentWindow, { source: 'preview-ready' });
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores ready signals from other previews' iframes", () => {
     const { container } = render(<Preview code="show(42);" err="" />);
     const iframe = container.querySelector('iframe') as HTMLIFrameElement;
     const postMessage = vi.fn();
@@ -30,15 +56,80 @@ describe('Preview', () => {
       value: { postMessage },
     });
 
-    vi.advanceTimersByTime(PREVIEW_EXECUTE_DELAY_MS - 10);
+    postIframeMessage(null, { source: 'preview-ready' });
     expect(postMessage).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(10);
-    expect(postMessage).toHaveBeenCalledWith('show(42);', '*');
   });
 
   it('shows bundling errors over the preview', () => {
     render(<Preview code="" err="Cannot resolve module" />);
     expect(screen.getByText('Cannot resolve module')).toBeInTheDocument();
+  });
+
+  it('patches the iframe console to forward log entries', () => {
+    render(<Preview code="" err="" />);
+    const srcdoc = (
+      screen.getByTitle('preview') as HTMLIFrameElement
+    ).getAttribute('srcdoc');
+    expect(srcdoc).toContain("'preview-console'");
+    expect(srcdoc).toContain("['log', 'info', 'warn', 'error', 'debug']");
+  });
+
+  it('renders forwarded console entries with their level', () => {
+    const { container } = render(<Preview code="" err="" />);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    expect(container.querySelector('.preview-console')).toBeNull();
+
+    postConsoleMessage(iframe.contentWindow, 'log', 'hello world');
+    postConsoleMessage(iframe.contentWindow, 'error', 'boom');
+
+    expect(screen.getByText('hello world')).toHaveClass('preview-console-log');
+    expect(screen.getByText('boom')).toHaveClass('preview-console-error');
+    expect(screen.getByText('Console (2)')).toBeInTheDocument();
+  });
+
+  it("ignores messages that aren't from its own iframe", () => {
+    const { container } = render(<Preview code="" err="" />);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    postConsoleMessage(null, 'log', 'someone elses log');
+    postConsoleMessage(iframe.contentWindow, 'log', 'mine');
+
+    expect(screen.queryByText('someone elses log')).toBeNull();
+    expect(screen.getByText('mine')).toBeInTheDocument();
+  });
+
+  it('caps stored entries and says the oldest were dropped', () => {
+    const { container } = render(<Preview code="" err="" />);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    for (let i = 0; i < MAX_CONSOLE_ENTRIES + 5; i++) {
+      postConsoleMessage(iframe.contentWindow, 'log', `entry ${i}`);
+    }
+
+    expect(container.querySelectorAll('.preview-console-entry')).toHaveLength(
+      MAX_CONSOLE_ENTRIES
+    );
+    expect(screen.queryByText('entry 0')).toBeNull();
+    expect(
+      screen.getByText(`Console (${MAX_CONSOLE_ENTRIES}, oldest dropped)`)
+    ).toBeInTheDocument();
+  });
+
+  it('clears entries via the button and on a new run', () => {
+    const { container, rerender } = render(<Preview code="a" err="" />);
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    postConsoleMessage(iframe.contentWindow, 'log', 'first');
+    act(() => {
+      screen.getByText('Clear').click();
+    });
+    expect(container.querySelector('.preview-console')).toBeNull();
+
+    postConsoleMessage(iframe.contentWindow, 'log', 'second');
+    expect(screen.getByText('second')).toBeInTheDocument();
+
+    rerender(<Preview code="b" err="" />);
+    expect(container.querySelector('.preview-console')).toBeNull();
   });
 });

--- a/jbook/packages/local-client/src/components/preview.tsx
+++ b/jbook/packages/local-client/src/components/preview.tsx
@@ -1,10 +1,17 @@
 import './preview.css';
-import { useRef, useEffect } from 'react';
-import { PREVIEW_EXECUTE_DELAY_MS } from '../constants';
+import { useRef, useEffect, useState } from 'react';
+import { MAX_CONSOLE_ENTRIES } from '../constants';
 
 interface PreviewProps {
   code: string;
   err: string;
+}
+
+type ConsoleLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
+
+interface ConsoleEntry {
+  level: ConsoleLevel;
+  text: string;
 }
 
 const html = `
@@ -15,6 +22,42 @@ const html = `
       <body>
         <div id="root"></div>
         <script>
+          // Console arguments can hold anything (cyclic objects, functions,
+          // DOM nodes) so they can't cross postMessage as-is; flatten each to
+          // a string on this side of the boundary.
+          const serialize = (value) => {
+            if (typeof value === 'string') return value;
+            if (value instanceof Error) return String(value);
+            if (typeof value === 'object' && value !== null) {
+              const seen = new WeakSet();
+              try {
+                const json = JSON.stringify(value, (key, v) => {
+                  if (typeof v === 'object' && v !== null) {
+                    if (seen.has(v)) return '[Circular]';
+                    seen.add(v);
+                  }
+                  if (typeof v === 'function') return String(v);
+                  if (typeof v === 'bigint') return v.toString() + 'n';
+                  return v;
+                });
+                if (json !== undefined) return json;
+              } catch (err) {}
+            }
+            return String(value);
+          };
+
+          ['log', 'info', 'warn', 'error', 'debug'].forEach((level) => {
+            const original = console[level].bind(console);
+            console[level] = (...args) => {
+              original(...args);
+              window.parent.postMessage({
+                source: 'preview-console',
+                level,
+                text: args.map(serialize).join(' '),
+              }, '*');
+            };
+          });
+
           const handleError = (err) => {
             const root = document.querySelector('#root');
             root.innerHTML = '<div style="color: red;"><h4>Runtime Error</h4>' + err + '</div>';
@@ -33,6 +76,11 @@ const html = `
               handleError(err);
             }
           }, false);
+
+          // Everything is installed; tell the parent this document can accept
+          // code. Posting on a fixed timer instead used to drop the bundle
+          // whenever the iframe loaded slower than the delay.
+          window.parent.postMessage({ source: 'preview-ready' }, '*');
         </script>
       </body>
     </html>
@@ -40,32 +88,91 @@ const html = `
 
 const Preview: React.FC<PreviewProps> = ({ code, err }) => {
   const iframe = useRef<any>();
+  const consoleBody = useRef<HTMLDivElement | null>(null);
+  // Held until the iframe document reports ready; posting sooner loses the
+  // message because the document's listener doesn't exist yet.
+  const pendingCode = useRef<string | null>(null);
+  const [logs, setLogs] = useState<ConsoleEntry[]>([]);
 
   useEffect(() => {
     if (!iframe.current) {
       return;
     }
+    setLogs([]);
+    pendingCode.current = code;
+    // The iframe deliberately has no srcDoc attribute in JSX: this assignment
+    // is the only load, so exactly one document fires 'ready' and executes
+    // the code. (Assigning srcdoc always reloads, even with the same value.)
     iframe.current.srcdoc = html;
-    const timer = setTimeout(() => {
-      // The component may unmount (or the iframe detach) before the settle
-      // delay elapses; an uncancelled timer would then dereference null.
-      iframe.current?.contentWindow?.postMessage(code, '*');
-    }, PREVIEW_EXECUTE_DELAY_MS);
-
-    return () => {
-      clearTimeout(timer);
-    };
   }, [code]);
+
+  useEffect(() => {
+    // Every Preview on the page listens on the same window; the source check
+    // keeps one cell's messages out of another cell's preview.
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== iframe.current?.contentWindow) {
+        return;
+      }
+
+      if (event.data?.source === 'preview-ready') {
+        if (pendingCode.current !== null) {
+          iframe.current?.contentWindow?.postMessage(pendingCode.current, '*');
+          pendingCode.current = null;
+        }
+        return;
+      }
+
+      if (event.data?.source === 'preview-console') {
+        const entry: ConsoleEntry = {
+          level: event.data.level,
+          text: String(event.data.text),
+        };
+        setLogs((prev) => [...prev, entry].slice(-MAX_CONSOLE_ENTRIES));
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    return () => {
+      window.removeEventListener('message', onMessage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (consoleBody.current) {
+      consoleBody.current.scrollTop = consoleBody.current.scrollHeight;
+    }
+  }, [logs]);
 
   return (
     <div className="preview-wrapper">
-      <iframe
-        title="preview"
-        ref={iframe}
-        sandbox="allow-scripts"
-        srcDoc={html}
-      />
+      <iframe title="preview" ref={iframe} sandbox="allow-scripts" />
       {err && <div className="preview-error">{err}</div>}
+      {logs.length > 0 && (
+        <div className="preview-console">
+          <div className="preview-console-header">
+            <span className="preview-console-title">
+              Console ({logs.length}
+              {logs.length >= MAX_CONSOLE_ENTRIES ? ', oldest dropped' : ''})
+            </span>
+            <button
+              className="preview-console-clear"
+              onClick={() => setLogs([])}
+            >
+              Clear
+            </button>
+          </div>
+          <div className="preview-console-body" ref={consoleBody}>
+            {logs.map((entry, i) => (
+              <div
+                key={i}
+                className={`preview-console-entry preview-console-${entry.level}`}
+              >
+                {entry.text}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/jbook/packages/local-client/src/constants.ts
+++ b/jbook/packages/local-client/src/constants.ts
@@ -13,13 +13,12 @@ export const PERSIST_SAVE_DEBOUNCE_MS = 250;
 // coalesces bursts of keystrokes.
 export const JSX_HIGHLIGHT_DEBOUNCE_MS = 100;
 
-// Pause between resetting the preview iframe's srcdoc and posting the bundled
-// code into it, giving the fresh document time to install its message
-// listener. A load-event handshake would be more principled; this matches the
-// app's long-standing behavior.
-export const PREVIEW_EXECUTE_DELAY_MS = 50;
-
 // Maximum number of undo history entries kept for the notebook. Snapshots are
 // cheap (cells are small JSON), and 50 comfortably covers a working session
 // without unbounded growth.
 export const UNDO_HISTORY_LIMIT = 50;
+
+// Maximum console entries kept per preview. A console.log inside a loop can
+// emit thousands of messages per second; keeping only the newest N bounds
+// both memory and re-render cost while still showing where the output ended.
+export const MAX_CONSOLE_ENTRIES = 200;


### PR DESCRIPTION
## Summary

Two changes to the preview pane, one feature and one bug fix found while verifying it.

### Console capture (new)
- The preview iframe patches `console.log/info/warn/error/debug` before executing cell code and forwards each call to the parent. Arguments are serialized on the iframe side — cyclic objects become `[Circular]`; functions, bigints, and Errors are stringified — since raw console arguments can't cross `postMessage`.
- A console panel renders under the preview whenever there's output: entry count in the header, warn/error tinted with the accent ramp, debug dimmed, auto-scroll to newest, a **Clear** button, and a 200-entry cap (header says "oldest dropped" when trimming) so a `console.log` in a loop can't eat the tab.
- Messages are filtered by source window, so each cell's console only shows its own iframe's output. Runtime errors now appear in the console as well as the red overlay.

### Racy code handoff (fixed)
The preview could silently render nothing — intermittently, including on the published 3.3.0. Two compounding causes:
- The bundled code was posted into the iframe on a fixed 50 ms timer (`PREVIEW_EXECUTE_DELAY_MS`), so whenever the iframe document hadn't installed its message listener within 50 ms the code was lost with no retry.
- The iframe loaded twice (JSX `srcDoc` attribute + effect assignment — assigning `srcdoc` always reloads), so a second load could wipe output that had already rendered.

Now the iframe document posts a `ready` signal once its listener is installed, and the parent posts the code exactly once, on that signal; the JSX attribute and the timer constant are gone. This is the load-event handshake the old comment in constants.ts flagged as the more principled design.

## Verification
- Preview test suite grows 3 → 9: capture and level styling, cross-iframe filtering, the entry cap, clearing (button + new run), and the ready handshake including the duplicate-ready case. 77 tests green across the workspace.
- Verified visually in the production build (served via the CLI bundle): three consecutive hard reloads all rendered both the `show()` JSX output and the console panel, where the old timer-based handoff blanked the preview roughly every other load. Clear button exercised interactively.

Release note: this bumps `@my-scrapbook/local-client` at the next release (first change since 3.2.0).