### PR TITLE
Prepare the 3.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.4.0 — 2026-08-02
 
 ### Added
 - **Console output in the preview.** `console.log`/`info`/`warn`/`error`/`debug` calls in cell code now show up in a console panel under the preview pane: objects are serialized (cycles become `[Circular]`), warnings and errors are tinted, the panel keeps the newest 200 entries, auto-scrolls, and has a **Clear** button. Runtime errors still render in the preview and now land in the console too.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.4
+
+- **Console output in the preview.** `console.log` (and `info`/`warn`/`error`/`debug`) from your code now shows up in a console panel right under the preview — objects serialized, warnings and errors highlighted, with a **Clear** button. No more digging through the browser devtools.
+- **The preview no longer goes randomly blank.** Bundled code used to be handed to the preview on a fixed timer and was silently lost if the preview loaded slower; it's now delivered on an explicit ready signal, every time.
+
 ## What's new in 3.3
 
 - **Markdown export.** `npx my-scrapbook export` turns a notebook into a plain markdown file you can share anywhere — see "Export a notebook to Markdown" above.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.3.0"
+  "version": "3.4.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14520,7 +14520,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15049,7 +15049,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.2.0",
+      "version": "3.4.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/parser": "^7.26.0",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -50,6 +50,11 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.4
+
+- **Console output in the preview.** `console.log` (and `info`/`warn`/`error`/`debug`) from your code now shows up in a console panel right under the preview — objects serialized, warnings and errors highlighted, with a **Clear** button. No more digging through the browser devtools.
+- **The preview no longer goes randomly blank.** Bundled code used to be handed to the preview on a fixed timer and was silently lost if the preview loaded slower; it's now delivered on an explicit ready signal, every time.
+
 ## What's new in 3.3
 
 - **Markdown export.** `npx my-scrapbook export` turns a notebook into a plain markdown file you can share anywhere — see "Export a notebook to Markdown" above.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.2.0",
+  "version": "3.4.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.4.0, carrying [PR #33](https://github.com/dannysarco/code-editor/pull/33)'s preview console panel and iframe ready-handshake fix.

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.4.0 (the cli package tracks the release version per the 3.2.0 precedent, so the npm page reflects the release even though the change lives in local-client); local-api and types remain 3.0.0, covered by `^3.0.0` ranges. `lerna.json` syncs to 3.4.0.
- Changelog's Unreleased section becomes **3.4.0 — 2026-08-02**.
- "What's new in 3.4" sections added to the root and cli READMEs.

## Verification
- 96 tests green across the workspace (cli 9, local-api 10, local-client 77).
- Both packages build; the rebuilt CLI bundle reports 3.4.0.
- `npm pack --dry-run`: cli 588.5 kB / 3 files; local-client 7.9 MB / 123 files (unchanged from 3.2.0).

After merge: publish **both** `@my-scrapbook/local-client` and `my-scrapbook` (two OTP prompts) from a freshly pulled main checkout, then tag `v3.4.0`.