### PR TITLE
Support TypeScript in code cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **TypeScript in code cells.** Cell code is now bundled with esbuild's `tsx` loader, so interfaces, type annotations, generics, and `.tsx`-style JSX all work — types are stripped at bundle time (no type checking). The editor treats cells as TypeScript models: TS syntax highlights correctly (including through the JSX highlighter), syntax errors squiggle, and the **Format** button uses prettier's `babel-ts` parser. Semantic validation is intentionally off since unpkg imports have no type definitions to check against. Plain JavaScript cells work exactly as before.
+
 ## 3.4.0 — 2026-08-02
 
 ### Added

--- a/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.test.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.test.ts
@@ -46,11 +46,12 @@ describe('fetch plugin', () => {
     vi.mocked(axios.get).mockReset();
   });
 
-  it('serves the entry point from the raw cell code', async () => {
-    const load = makeLoader('show(42);');
+  it('serves the entry point from the raw cell code as tsx', async () => {
+    // tsx so cells can use TypeScript syntax; plain JS/JSX parses the same.
+    const load = makeLoader('const n: number = 42;\nshow(n);');
     expect(await load({ path: 'index.js' })).toEqual({
-      loader: 'jsx',
-      contents: 'show(42);',
+      loader: 'tsx',
+      contents: 'const n: number = 42;\nshow(n);',
     });
   });
 

--- a/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
@@ -8,7 +8,9 @@ export const fetchPlugin = (inputCode: string) => {
     setup(build: esbuild.PluginBuild) {
       build.onLoad({ filter: /(^index\.js$)/ }, () => {
         return {
-          loader: 'jsx',
+          // tsx rather than jsx: cell code may use TypeScript syntax, which
+          // esbuild strips (no type checking). Plain JS/JSX parses the same.
+          loader: 'tsx',
           contents: inputCode,
         };
       });

--- a/jbook/packages/local-client/src/components/code-editor.tsx
+++ b/jbook/packages/local-client/src/components/code-editor.tsx
@@ -1,7 +1,7 @@
 import '../monaco-setup';
 import './code-editor.css';
 import './syntax.css';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import Editor, { OnMount } from '@monaco-editor/react';
 import prettier from 'prettier/standalone';
 import parser from 'prettier/parser-babel';
@@ -10,9 +10,14 @@ import traverse from '@babel/traverse';
 import MonacoJSXHighlighter, { makeBabelParse } from 'monaco-jsx-highlighter';
 import { JSX_HIGHLIGHT_DEBOUNCE_MS } from '../constants';
 
-// Configures @babel/parser for module source type + JSX with error recovery;
-// the raw parse function rejects top-level import/export statements.
-const babelParse = makeBabelParse(parse);
+// Configures @babel/parser for module source type + JSX + TypeScript with
+// error recovery; the raw parse function rejects top-level import/export
+// statements, and without the second flag TS syntax would kill highlighting.
+const babelParse = makeBabelParse(parse, true);
+
+// Each editor needs its own model path (Monaco keys models by URI), and the
+// .tsx extension is what makes the TypeScript worker accept JSX syntax.
+let editorSeq = 0;
 
 interface CodeEditorProps {
   initialValue: string;
@@ -21,6 +26,7 @@ interface CodeEditorProps {
 
 const CodeEditor: React.FC<CodeEditorProps> = ({ onChange, initialValue }) => {
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const [modelPath] = useState(() => `cell-${++editorSeq}.tsx`);
 
   const onEditorMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
@@ -58,7 +64,9 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ onChange, initialValue }) => {
     // format that value
     const formatted = prettier
       .format(unformatted, {
-        parser: 'babel',
+        // babel-ts handles TypeScript and is a superset of what the plain
+        // babel parser accepted for JS/JSX cells.
+        parser: 'babel-ts',
         plugins: [parser],
         useTabs: false,
         semi: true,
@@ -73,7 +81,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ onChange, initialValue }) => {
   return (
     <div className="editor-wrapper">
       <div className="pane-toolbar editor-toolbar">
-        <span className="label editor-language">JavaScript</span>
+        <span className="label editor-language">JS / TS</span>
         <button className="format-btn" onClick={onFormatClick}>
           Format
         </button>
@@ -84,7 +92,8 @@ const CodeEditor: React.FC<CodeEditorProps> = ({ onChange, initialValue }) => {
           value={initialValue}
           onChange={(value) => onChange(value ?? '')}
           theme="modernist-dark"
-          language="javascript"
+          language="typescript"
+          path={modelPath}
           height="100%"
           options={{
             wordWrap: 'on',

--- a/jbook/packages/local-client/src/components/example-text.tsx
+++ b/jbook/packages/local-client/src/components/example-text.tsx
@@ -13,6 +13,10 @@ const GUIDE_ITEMS: React.ReactNode[] = [
     preview.
   </>,
   <>Import any npm package — bundling happens in the browser.</>,
+  <>
+    Code cells accept TypeScript too — types are stripped before the code
+    runs.
+  </>,
 ];
 
 const ExplainerText: React.FC = () => {

--- a/jbook/packages/local-client/src/monaco-setup.ts
+++ b/jbook/packages/local-client/src/monaco-setup.ts
@@ -2,7 +2,7 @@
 // package instead of @monaco-editor/react's default CDN loader, so the app
 // works fully offline. Vite's ?worker imports produce the web workers Monaco
 // needs; only the base editor worker and the typescript worker are included
-// since the notebook only edits JavaScript.
+// since the notebook only edits TypeScript/JavaScript.
 import * as monaco from 'monaco-editor';
 import { loader } from '@monaco-editor/react';
 import EditorWorker from 'monaco-editor/editor/editor.worker.js?worker';
@@ -43,6 +43,22 @@ monaco.editor.defineTheme('modernist-dark', {
     'scrollbarSlider.background': '#44414180',
     'scrollbarSlider.hoverBackground': '#605d5d80',
   },
+});
+
+// Cell models are .tsx so TypeScript and JSX both parse. Semantic validation
+// is off: the language service has no type definitions for react or anything
+// else imported from unpkg, so every import would squiggle "cannot find
+// module". Syntax errors still show.
+monaco.typescript.typescriptDefaults.setCompilerOptions({
+  jsx: monaco.typescript.JsxEmit.React,
+  target: monaco.typescript.ScriptTarget.ESNext,
+  moduleResolution: monaco.typescript.ModuleResolutionKind.NodeJs,
+  allowNonTsExtensions: true,
+  esModuleInterop: true,
+});
+monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
+  noSemanticValidation: true,
+  noSyntaxValidation: false,
 });
 
 self.MonacoEnvironment = {


### PR DESCRIPTION
## Summary

Code cells now accept TypeScript — interfaces, type annotations, generics, and `.tsx`-style JSX — with types stripped at bundle time. Plain JavaScript cells work exactly as before.

### How each layer handles it
- **Bundler**: the cell entry point uses esbuild's `tsx` loader instead of `jsx`. esbuild strips types during transpilation (no type checking). JS/JSX parses identically under `tsx`, so existing notebooks are unaffected.
- **Editor**: cells are Monaco TypeScript models with unique `.tsx` paths — the extension is what makes the TS worker accept JSX syntax. Toolbar label is now **JS / TS**.
- **Diagnostics**: compiler options set JSX + ESNext; semantic validation is deliberately **off** — the language service has no type definitions for react or anything imported from unpkg, so every import would falsely squiggle "cannot find module". Syntax errors still squiggle. (Real type checking would need bundled type defs for unpkg imports — out of scope.)
- **JSX highlighter**: parses with Babel's `typescript` plugin via `makeBabelParse`'s second flag, so TS syntax doesn't kill highlighting.
- **Format button**: prettier's `babel-ts` parser — already shipped inside the bundled `parser-babel` plugin, no new dependency.
- The in-app guide gained item 05: "Code cells accept TypeScript too — types are stripped before the code runs."

One migration note: Monaco 0.56 moved the config API from `monaco.languages.typescript` (now a deprecated stub) to the top-level `monaco.typescript` namespace.

## Verification
- 77 local-client tests green; the fetch-plugin test now asserts the `tsx` loader with typed content.
- In the production build: a cell with an `interface`, a generic `<T extends Point>` arrow function, typed JSX, and `console.log` of a typed object highlights cleanly with zero bogus squiggles, bundles in ~800 ms, renders the computed values in the preview, logs to the console panel, and formats cleanly via the Format button.

Release note: ships as 3.5.0 (local-client + cli bump).