### PR TITLE
Prepare the 3.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.5.0 — 2026-08-02
 
 ### Added
 - **TypeScript in code cells.** Cell code is now bundled with esbuild's `tsx` loader, so interfaces, type annotations, generics, and `.tsx`-style JSX all work — types are stripped at bundle time (no type checking). The editor treats cells as TypeScript models: TS syntax highlights correctly (including through the JSX highlighter), syntax errors squiggle, and the **Format** button uses prettier's `babel-ts` parser. Semantic validation is intentionally off since unpkg imports have no type definitions to check against. Plain JavaScript cells work exactly as before.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.5
+
+- **TypeScript in code cells.** Interfaces, type annotations, and generics all work — the editor highlights TS properly, the **Format** button understands it, and types are stripped when your code runs (no type checking). Plain JavaScript works exactly as before.
+
 ## What's new in 3.4
 
 - **Console output in the preview.** `console.log` (and `info`/`warn`/`error`/`debug`) from your code now shows up in a console panel right under the preview — objects serialized, warnings and errors highlighted, with a **Clear** button. No more digging through the browser devtools.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.4.0"
+  "version": "3.5.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14520,7 +14520,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15049,7 +15049,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/parser": "^7.26.0",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -50,6 +50,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.5
+
+- **TypeScript in code cells.** Interfaces, type annotations, and generics all work — the editor highlights TS properly, the **Format** button understands it, and types are stripped when your code runs (no type checking). Plain JavaScript works exactly as before.
+
 ## What's new in 3.4
 
 - **Console output in the preview.** `console.log` (and `info`/`warn`/`error`/`debug`) from your code now shows up in a console panel right under the preview — objects serialized, warnings and errors highlighted, with a **Clear** button. No more digging through the browser devtools.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.5.0, carrying [PR #35](https://github.com/dannysarco/code-editor/pull/35)'s TypeScript support in code cells.

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.5.0; local-api and types remain 3.0.0, covered by `^3.0.0` ranges. `lerna.json` syncs to 3.5.0.
- Changelog's Unreleased section becomes **3.5.0 — 2026-08-02**.
- "What's new in 3.5" sections added to the root and cli READMEs.

## Verification
- 96 tests green across the workspace (cli 9, local-api 10, local-client 77).
- Both packages build; the rebuilt CLI bundle reports 3.5.0.
- `npm pack --dry-run`: cli 588.6 kB / 3 files; local-client 7.9 MB / 123 files.

After merge: publish **both** `@my-scrapbook/local-client` and `my-scrapbook` (two OTP prompts) from a freshly pulled main checkout, then tag `v3.5.0`.