### PR TITLE
Cache bundle outputs so unchanged cells skip esbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Unchanged cells no longer re-run esbuild.** Bundle outputs are cached two ways: an in-memory store for same-session repeats (undo/redo, moving a cell and moving it back, Run all over unchanged cells) and one persisted entry per cell in IndexedDB, which makes an unchanged notebook load instantly on reload instead of rebundling every cell. Cells served this way say "Bundled from cache" in their header. Only successful bundles are cached, and **Clear cache** empties the bundle cache along with the module cache (cached outputs pin the module versions they were built with). Cumulative cell code is also now memoized, so it only recomputes when cells actually change rather than on every store update.
+
 ## 3.5.0 — 2026-08-02
 
 ### Added

--- a/jbook/packages/local-client/src/bundler/bundle-cache.test.ts
+++ b/jbook/packages/local-client/src/bundler/bundle-cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const persistent = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  clear: vi.fn(),
+}));
+
+vi.mock('localforage', () => ({
+  default: {
+    createInstance: () => persistent,
+  },
+}));
+
+import {
+  clearBundleCache,
+  getCachedBundle,
+  setCachedBundle,
+} from './bundle-cache';
+
+describe('bundle cache', () => {
+  beforeEach(async () => {
+    persistent.getItem.mockReset().mockResolvedValue(null);
+    persistent.setItem.mockReset().mockResolvedValue(undefined);
+    persistent.clear.mockReset().mockResolvedValue(undefined);
+    // The in-memory layer is module state; empty it between tests.
+    await clearBundleCache();
+    persistent.clear.mockClear();
+  });
+
+  it('returns same-session results from memory without touching storage', async () => {
+    await setCachedBundle('cell-1', 'input-a', { code: 'out-a', err: '' });
+
+    const result = await getCachedBundle('cell-1', 'input-a');
+    expect(result).toEqual({ code: 'out-a', err: '' });
+    expect(persistent.getItem).not.toHaveBeenCalled();
+  });
+
+  it('shares memory entries across cells with identical input', async () => {
+    await setCachedBundle('cell-1', 'same-input', { code: 'out', err: '' });
+
+    expect(await getCachedBundle('cell-2', 'same-input')).toEqual({
+      code: 'out',
+      err: '',
+    });
+  });
+
+  it('falls back to the persisted per-cell entry on matching input', async () => {
+    persistent.getItem.mockResolvedValue({ input: 'input-a', code: 'stored' });
+
+    expect(await getCachedBundle('cell-1', 'input-a')).toEqual({
+      code: 'stored',
+      err: '',
+    });
+    expect(persistent.getItem).toHaveBeenCalledWith('cell-1');
+  });
+
+  it('promotes persistent hits into memory so undo works after an edit overwrites the per-cell entry', async () => {
+    // Reload: served from the persistent layer.
+    persistent.getItem.mockResolvedValue({ input: 'original', code: 'out-a' });
+    await getCachedBundle('cell-1', 'original');
+
+    // Edit: the cell's persistent entry now holds the new input.
+    persistent.getItem.mockResolvedValue({ input: 'edited', code: 'out-b' });
+
+    // Undo: only the promoted memory entry can serve the original input.
+    persistent.getItem.mockClear();
+    expect(await getCachedBundle('cell-1', 'original')).toEqual({
+      code: 'out-a',
+      err: '',
+    });
+    expect(persistent.getItem).not.toHaveBeenCalled();
+  });
+
+  it('misses when the persisted entry is for different input', async () => {
+    persistent.getItem.mockResolvedValue({ input: 'old-input', code: 'stale' });
+
+    expect(await getCachedBundle('cell-1', 'new-input')).toBeNull();
+  });
+
+  it('does not cache failed bundles', async () => {
+    await setCachedBundle('cell-1', 'bad-input', {
+      code: '',
+      err: 'syntax error',
+    });
+
+    expect(persistent.setItem).not.toHaveBeenCalled();
+    expect(await getCachedBundle('cell-1', 'bad-input')).toBeNull();
+  });
+
+  it('evicts the least recently used memory entry beyond the cap', async () => {
+    for (let i = 0; i < 11; i++) {
+      await setCachedBundle('cell-1', `input-${i}`, {
+        code: `out-${i}`,
+        err: '',
+      });
+    }
+
+    // input-0 was evicted (memory miss falls through to storage, which has
+    // only the latest entry for the cell); input-10 is still in memory.
+    persistent.getItem.mockResolvedValue(null);
+    expect(await getCachedBundle('cell-1', 'input-0')).toBeNull();
+    persistent.getItem.mockClear();
+    expect(await getCachedBundle('cell-1', 'input-10')).toEqual({
+      code: 'out-10',
+      err: '',
+    });
+    expect(persistent.getItem).not.toHaveBeenCalled();
+  });
+
+  it('clear empties both layers', async () => {
+    await setCachedBundle('cell-1', 'input-a', { code: 'out-a', err: '' });
+
+    await clearBundleCache();
+
+    expect(persistent.clear).toHaveBeenCalledTimes(1);
+    persistent.getItem.mockResolvedValue(null);
+    expect(await getCachedBundle('cell-1', 'input-a')).toBeNull();
+  });
+});

--- a/jbook/packages/local-client/src/bundler/bundle-cache.ts
+++ b/jbook/packages/local-client/src/bundler/bundle-cache.ts
@@ -1,0 +1,84 @@
+import localForage from 'localforage';
+import type { BundleResult } from '@my-scrapbook/types';
+
+// Bundling is deterministic given a cell's cumulative source and the pinned
+// module cache, so a bundle's output can be reused whenever the same input
+// comes back: page reload, undo/redo, moving a cell and moving it back, or
+// Run all over unchanged cells. Two layers:
+//
+// - an in-memory LRU keyed by the input source, for same-session repeats
+//   whose input is no longer any cell's latest (undo/redo, reorders);
+// - one persistent entry per cell (IndexedDB) holding the latest input and
+//   output, which is what makes an unchanged notebook load instantly on
+//   reload while keeping storage bounded by notebook size. Entries for
+//   deleted cells linger until Clear cache; they're never served because
+//   lookups require an exact input match.
+//
+// Only successful bundles are cached, and the cache is cleared together with
+// the module cache: outputs bake in whatever module versions were pinned
+// when they were built.
+
+const MAX_MEMORY_ENTRIES = 10;
+
+const memoryCache = new Map<string, BundleResult>();
+
+const persistentCache = localForage.createInstance({
+  name: 'bundlecache',
+});
+
+interface PersistentEntry {
+  input: string;
+  code: string;
+}
+
+export const getCachedBundle = async (
+  cellId: string,
+  input: string
+): Promise<BundleResult | null> => {
+  const inMemory = memoryCache.get(input);
+  if (inMemory) {
+    // Re-insert so recently used entries survive eviction longest.
+    memoryCache.delete(input);
+    memoryCache.set(input, inMemory);
+    return inMemory;
+  }
+
+  const stored = await persistentCache.getItem<PersistentEntry>(cellId);
+  if (stored && stored.input === input) {
+    const result: BundleResult = { code: stored.code, err: '' };
+    // Promote into memory: the persistent layer only keeps a cell's latest
+    // input, so once an edit overwrites it, undoing back to this input can
+    // only be served from here (reload → edit → undo).
+    memoryCache.set(input, result);
+    return result;
+  }
+
+  return null;
+};
+
+export const setCachedBundle = async (
+  cellId: string,
+  input: string,
+  result: BundleResult
+): Promise<void> => {
+  if (result.err) {
+    return;
+  }
+
+  memoryCache.set(input, result);
+  while (memoryCache.size > MAX_MEMORY_ENTRIES) {
+    // Map iteration order is insertion order, so the first key is the least
+    // recently used (gets refresh re-inserted on every hit).
+    memoryCache.delete(memoryCache.keys().next().value as string);
+  }
+
+  await persistentCache.setItem<PersistentEntry>(cellId, {
+    input,
+    code: result.code,
+  });
+};
+
+export const clearBundleCache = async (): Promise<void> => {
+  memoryCache.clear();
+  await persistentCache.clear();
+};

--- a/jbook/packages/local-client/src/components/cell-list-item.tsx
+++ b/jbook/packages/local-client/src/components/cell-list-item.tsx
@@ -18,6 +18,8 @@ const CellListItem: React.FC<CellListItemProps> = ({ cell, index }) => {
   if (cell.type === 'code') {
     if (!bundle || bundle.loading) {
       status = 'Bundling…';
+    } else if (bundle.cached) {
+      status = 'Bundled from cache';
     } else if (bundle.durationMs !== undefined) {
       status = `Bundled in ${Math.max(1, Math.round(bundle.durationMs))} ms`;
     }

--- a/jbook/packages/local-client/src/components/code-cell.test.tsx
+++ b/jbook/packages/local-client/src/components/code-cell.test.tsx
@@ -16,6 +16,12 @@ vi.mock('./code-editor', () => ({
   ),
 }));
 vi.mock('../bundler', () => ({ default: vi.fn() }));
+// The thunk consults the bundle cache before running the bundler; a real
+// cache (localforage) never resolves under jsdom + fake timers.
+vi.mock('../bundler/bundle-cache', () => ({
+  getCachedBundle: vi.fn().mockResolvedValue(null),
+  setCachedBundle: vi.fn().mockResolvedValue(undefined),
+}));
 
 const cell: Cell = { id: 'a', type: 'code', content: "show('one');" };
 
@@ -39,12 +45,14 @@ describe('CodeCell', () => {
     // rather than by role: react-resizable's Infinity inline widths crash
     // jsdom's computed-style walk during accessibility-tree checks.)
     expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
-    expect(bundler).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(bundler).mock.calls[0][0]).toContain("show('one');");
 
     await act(async () => {
+      // One flush for the cache-miss lookup, after which the bundler runs
+      // and its result commits.
       await vi.advanceTimersByTimeAsync(0);
     });
+    expect(bundler).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(bundler).mock.calls[0][0]).toContain("show('one');");
 
     expect(container.querySelector('[role="progressbar"]')).toBeNull();
     expect(screen.getByTitle('preview')).toBeInTheDocument();

--- a/jbook/packages/local-client/src/components/offline-status.test.tsx
+++ b/jbook/packages/local-client/src/components/offline-status.test.tsx
@@ -4,14 +4,20 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import OfflineStatus from './offline-status';
 import { clearModuleCache } from '../bundler/module-cache';
+import { clearBundleCache } from '../bundler/bundle-cache';
 
 vi.mock('../bundler/module-cache', () => ({
   clearModuleCache: vi.fn(),
 }));
 
+vi.mock('../bundler/bundle-cache', () => ({
+  clearBundleCache: vi.fn(),
+}));
+
 describe('OfflineStatus', () => {
   beforeEach(() => {
     vi.mocked(clearModuleCache).mockReset().mockResolvedValue(4);
+    vi.mocked(clearBundleCache).mockReset().mockResolvedValue(undefined);
   });
 
   it('shows no offline badge while online', () => {
@@ -43,6 +49,9 @@ describe('OfflineStatus', () => {
     );
 
     expect(clearModuleCache).toHaveBeenCalledTimes(1);
+    // Cached bundle outputs pin module versions, so both caches clear
+    // together.
+    expect(clearBundleCache).toHaveBeenCalledTimes(1);
     expect(
       await screen.findByText('Cleared 4 cached modules')
     ).toBeInTheDocument();

--- a/jbook/packages/local-client/src/components/offline-status.tsx
+++ b/jbook/packages/local-client/src/components/offline-status.tsx
@@ -1,6 +1,7 @@
 import './offline-status.css';
 import { useEffect, useState } from 'react';
 import { clearModuleCache } from '../bundler/module-cache';
+import { clearBundleCache } from '../bundler/bundle-cache';
 
 // Everything the app needs at runtime is served locally or cached: the
 // editor and bundler are part of the build, and npm modules fetched from
@@ -32,6 +33,10 @@ const OfflineStatus: React.FC = () => {
   }, [clearedCount]);
 
   const onClearCache = async () => {
+    // Cached bundle outputs bake in the pinned module versions, so they must
+    // go whenever the module cache does — otherwise unchanged cells would
+    // keep serving bundles built against the old versions.
+    await clearBundleCache();
     const count = await clearModuleCache();
     setClearedCount(count);
   };

--- a/jbook/packages/local-client/src/hooks/use-cumulative-code.ts
+++ b/jbook/packages/local-client/src/hooks/use-cumulative-code.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+import { createSelector } from '@reduxjs/toolkit';
 import { useTypedSelector } from './use-typed-selector';
 import { selectCells } from '../state';
 import { Cell } from '../state';
@@ -51,9 +53,18 @@ export const cumulativeCodeFor = (
 };
 
 export const useCumulativeCode = (cellId: string) => {
-  return useTypedSelector((state) => {
-    const { data, order } = selectCells(state);
-    const orderedCells = order.map((id) => data[id]);
-    return cumulativeCodeFor(orderedCells, cellId);
-  });
+  // Memoized per hook instance: the join only recomputes when the cells
+  // slice actually changes, not on every store dispatch (bundle lifecycle
+  // actions fire constantly while typing).
+  const selectCumulativeCode = useMemo(
+    () =>
+      createSelector([selectCells], ({ data, order }) =>
+        cumulativeCodeFor(
+          order.map((id) => data[id]),
+          cellId
+        )
+      ),
+    [cellId]
+  );
+  return useTypedSelector(selectCumulativeCode);
 };

--- a/jbook/packages/local-client/src/state/bundles-slice.test.ts
+++ b/jbook/packages/local-client/src/state/bundles-slice.test.ts
@@ -1,15 +1,27 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureStore } from '@reduxjs/toolkit';
 import reducer, { createBundle } from './bundles-slice';
 import bundler from '../bundler';
+import { getCachedBundle, setCachedBundle } from '../bundler/bundle-cache';
 
 vi.mock('../bundler', () => ({
   default: vi.fn(),
 }));
 
+vi.mock('../bundler/bundle-cache', () => ({
+  getCachedBundle: vi.fn(),
+  setCachedBundle: vi.fn(),
+}));
+
 const makeStore = () => configureStore({ reducer: { bundles: reducer } });
 
 describe('bundles slice', () => {
+  beforeEach(() => {
+    vi.mocked(bundler).mockReset();
+    vi.mocked(getCachedBundle).mockReset().mockResolvedValue(null);
+    vi.mocked(setCachedBundle).mockReset().mockResolvedValue(undefined);
+  });
+
   it('marks the cell as loading while bundling', async () => {
     let resolveBundle!: (value: { code: string; err: string }) => void;
     vi.mocked(bundler).mockReturnValue(
@@ -33,6 +45,36 @@ describe('bundles slice', () => {
       code: 'bundled!',
       err: '',
       durationMs: expect.any(Number),
+      cached: false,
+    });
+  });
+
+  it('serves a cached bundle without running the bundler', async () => {
+    vi.mocked(getCachedBundle).mockResolvedValue({ code: 'cached!', err: '' });
+    const store = makeStore();
+
+    await store.dispatch(createBundle('cell-1', 'show(1);'));
+
+    expect(bundler).not.toHaveBeenCalled();
+    expect(setCachedBundle).not.toHaveBeenCalled();
+    expect(store.getState().bundles['cell-1']).toEqual({
+      loading: false,
+      code: 'cached!',
+      err: '',
+      durationMs: undefined,
+      cached: true,
+    });
+  });
+
+  it('caches results after bundling', async () => {
+    vi.mocked(bundler).mockResolvedValue({ code: 'fresh', err: '' });
+    const store = makeStore();
+
+    await store.dispatch(createBundle('cell-1', 'show(1);'));
+
+    expect(setCachedBundle).toHaveBeenCalledWith('cell-1', 'show(1);', {
+      code: 'fresh',
+      err: '',
     });
   });
 
@@ -47,6 +89,7 @@ describe('bundles slice', () => {
       code: '',
       err: 'syntax error',
       durationMs: expect.any(Number),
+      cached: false,
     });
   });
 

--- a/jbook/packages/local-client/src/state/bundles-slice.ts
+++ b/jbook/packages/local-client/src/state/bundles-slice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import bundler from '../bundler';
+import { getCachedBundle, setCachedBundle } from '../bundler/bundle-cache';
 
 interface BundlesState {
   [key: string]:
@@ -10,6 +11,9 @@ interface BundlesState {
         // How long the bundle took, for the cell header's "Bundled in N ms"
         // label. Absent while loading and after unexpected failures.
         durationMs?: number;
+        // True when the result was served from the bundle cache instead of
+        // running esbuild; the cell header says so instead of a timing.
+        cached?: boolean;
       }
     | undefined;
 }
@@ -18,10 +22,27 @@ const initialState: BundlesState = {};
 
 const createBundleThunk = createAsyncThunk(
   'bundles/createBundle',
-  async ({ input }: { cellId: string; input: string }) => {
+  async ({
+    cellId,
+    input,
+  }: {
+    cellId: string;
+    input: string;
+  }): Promise<{
+    code: string;
+    err: string;
+    durationMs?: number;
+    cached: boolean;
+  }> => {
+    const cached = await getCachedBundle(cellId, input);
+    if (cached) {
+      return { ...cached, cached: true };
+    }
+
     const started = performance.now();
     const result = await bundler(input);
-    return { ...result, durationMs: performance.now() - started };
+    await setCachedBundle(cellId, input, result);
+    return { ...result, durationMs: performance.now() - started, cached: false };
   }
 );
 
@@ -48,6 +69,7 @@ const bundlesSlice = createSlice({
           code: action.payload.code,
           err: action.payload.err,
           durationMs: action.payload.durationMs,
+          cached: action.payload.cached,
         };
       })
       // bundler() reports errors through its result rather than throwing, so


### PR DESCRIPTION
## Summary

Implements the roadmap's "only rebundle affected cells" item — with an honest reframing of where the waste actually was. Editing a cell already only rebundled that cell and the ones below it (their cumulative input changes; upstream inputs don't), and downstream cells genuinely must rebundle. The real waste was re-running esbuild for **inputs it had already bundled**: page reload rebundled every cell from scratch, and undo/redo, moving a cell and moving it back, and **Run all** re-bundled identical inputs.

### Design
- **New `bundler/bundle-cache.ts`**, two layers:
  - an **in-memory LRU** (10 entries, keyed by exact cumulative input) for same-session repeats;
  - **one persisted IndexedDB entry per cell** (latest input + output), keeping storage bounded by notebook size — this is what makes an unchanged notebook **load instantly on reload**.
- Persistent hits are **promoted into memory**: without that, reload → edit → undo missed the cache, because the edit overwrites the cell's persistent entry. Caught during browser verification, locked in with a regression test.
- Only successful bundles are cached. The `createBundle` thunk consults the cache before invoking esbuild; cache-served cells say **"Bundled from cache"** in the header.
- **Clear cache** empties the bundle cache along with the module cache — cached outputs bake in the pinned module versions, so serving them past a module-cache clear would pin stale packages.
- `useCumulativeCode` is memoized with `createSelector` (the other half of the roadmap item), so the per-cell join recomputes only when cells change rather than on every store dispatch.

## Verification
- 87 local-client tests green: 8 new bundle-cache tests (memory hit, cross-cell sharing, persistent hit/miss, error non-caching, LRU eviction, promotion regression, clear), new thunk tests for the cached path and cache writes, and updated expectations elsewhere.
- Full behavioral sequence confirmed in the production build: first load bundles fresh (~1.5 s) → reload shows "Bundled from cache" instantly → edit rebundles fresh → **undo serves from cache** → Clear cache + reload bundles fresh again.

Release note: ships as 3.6.0 (local-client + cli bump).