### PR TITLE
Prepare the 3.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.6.0 — 2026-08-02
 
 ### Changed
 - **Unchanged cells no longer re-run esbuild.** Bundle outputs are cached two ways: an in-memory store for same-session repeats (undo/redo, moving a cell and moving it back, Run all over unchanged cells) and one persisted entry per cell in IndexedDB, which makes an unchanged notebook load instantly on reload instead of rebundling every cell. Cells served this way say "Bundled from cache" in their header. Only successful bundles are cached, and **Clear cache** empties the bundle cache along with the module cache (cached outputs pin the module versions they were built with). Cumulative cell code is also now memoized, so it only recomputes when cells actually change rather than on every store update.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.6
+
+- **Unchanged cells don't rebundle.** Bundle results are now cached, so reopening an unchanged notebook is instant, and undo/redo, moving a cell and moving it back, and **Run all** skip esbuild for anything already bundled — those cells say "Bundled from cache". **Clear cache** resets both the bundle and npm module caches.
+
 ## What's new in 3.5
 
 - **TypeScript in code cells.** Interfaces, type annotations, and generics all work — the editor highlights TS properly, the **Format** button understands it, and types are stripped when your code runs (no type checking). Plain JavaScript works exactly as before.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.5.0"
+  "version": "3.6.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14520,7 +14520,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15049,7 +15049,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/parser": "^7.26.0",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -50,6 +50,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.6
+
+- **Unchanged cells don't rebundle.** Bundle results are now cached, so reopening an unchanged notebook is instant, and undo/redo, moving a cell and moving it back, and **Run all** skip esbuild for anything already bundled — those cells say "Bundled from cache". **Clear cache** resets both the bundle and npm module caches.
+
 ## What's new in 3.5
 
 - **TypeScript in code cells.** Interfaces, type annotations, and generics all work — the editor highlights TS properly, the **Format** button understands it, and types are stripped when your code runs (no type checking). Plain JavaScript works exactly as before.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.6.0, carrying [PR #37](https://github.com/dannysarco/code-editor/pull/37)'s bundle-output cache.

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.6.0; local-api and types remain 3.0.0, covered by `^3.0.0` ranges. `lerna.json` syncs to 3.6.0.
- Changelog's Unreleased section becomes **3.6.0 — 2026-08-02**.
- "What's new in 3.6" sections added to the root and cli READMEs.

## Verification
- 106 tests green across the workspace (cli 9, local-api 10, local-client 87).
- Both packages build; the rebuilt CLI bundle reports 3.6.0.
- `npm pack --dry-run`: cli 588.7 kB / 3 files; local-client 7.9 MB / 123 files.

After merge: publish **both** `@my-scrapbook/local-client` and `my-scrapbook` (two OTP prompts) from a freshly pulled main checkout, then tag `v3.6.0`.