### PR TITLE
Add drag-to-reorder for cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Drag-to-reorder cells.** Every cell header has a grip handle — drag it to move the cell anywhere in the notebook (the one-step arrow buttons remain). The handle is keyboard-accessible (space to lift, arrows to move, space to drop), a drag counts as one undo step, and the new order saves to `notebook.js` like any other edit. Only the handle starts a drag, so selecting code or clicking in the preview is unaffected.
+
 ## 3.6.0 — 2026-08-02
 
 ### Changed

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -558,6 +558,59 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
@@ -7983,7 +8036,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8420,7 +8472,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11521,7 +11572,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -11534,7 +11584,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -12393,7 +12442,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -13598,7 +13646,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tuf-js": {
@@ -15051,6 +15098,11 @@
       "name": "@my-scrapbook/local-client",
       "version": "3.6.0",
       "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2"
+      },
       "devDependencies": {
         "@babel/parser": "^7.26.0",
         "@babel/traverse": "^7.26.0",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -62,5 +62,10 @@
   "homepage": "https://github.com/dannysarco/code-editor#readme",
   "bugs": {
     "url": "https://github.com/dannysarco/code-editor/issues"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2"
   }
 }

--- a/jbook/packages/local-client/src/components/cell-list-item.tsx
+++ b/jbook/packages/local-client/src/components/cell-list-item.tsx
@@ -1,4 +1,6 @@
 import './cell-list-item.css';
+import { GripVertical } from 'lucide-react';
+import type { DraggableAttributes } from '@dnd-kit/core';
 import { Cell } from '../state';
 import { useTypedSelector } from '../hooks/use-typed-selector';
 import CodeCell from './code-cell';
@@ -6,12 +8,26 @@ import TextEditor from './text-editor';
 import ActionBar from './action-bar';
 import ErrorBoundary from './error-boundary';
 
+// Activator props from useSortable: the whole cell is the sortable node, but
+// only the header grip starts a drag, so Monaco and the preview stay
+// interactive.
+export interface DragHandleProps {
+  ref: (element: HTMLElement | null) => void;
+  attributes: DraggableAttributes;
+  listeners?: Record<string, unknown>;
+}
+
 interface CellListItemProps {
   cell: Cell;
   index: number;
+  dragHandle?: DragHandleProps;
 }
 
-const CellListItem: React.FC<CellListItemProps> = ({ cell, index }) => {
+const CellListItem: React.FC<CellListItemProps> = ({
+  cell,
+  index,
+  dragHandle,
+}) => {
   const bundle = useTypedSelector((state) => state.bundles[cell.id]);
 
   let status: string | null = null;
@@ -28,6 +44,19 @@ const CellListItem: React.FC<CellListItemProps> = ({ cell, index }) => {
   return (
     <section className="cell-list-item ms-cell">
       <header className="cell-header">
+        {dragHandle && (
+          <button
+            type="button"
+            className="drag-handle"
+            aria-label="Drag to reorder cell"
+            title="Drag to reorder (or use the arrow buttons)"
+            ref={dragHandle.ref}
+            {...dragHandle.attributes}
+            {...dragHandle.listeners}
+          >
+            <GripVertical size={14} />
+          </button>
+        )}
         <span className="cell-index">{String(index + 1).padStart(2, '0')}</span>
         <span className="label">{cell.type === 'code' ? 'Code' : 'Text'}</span>
         {status && <span className="cell-status label">{status}</span>}

--- a/jbook/packages/local-client/src/components/cell-list.css
+++ b/jbook/packages/local-client/src/components/cell-list.css
@@ -78,3 +78,46 @@
 .empty-file {
   font-family: var(--font-mono);
 }
+
+/* Drag-to-reorder */
+
+.sortable-cell {
+  position: relative;
+}
+
+.sortable-cell.dragging {
+  z-index: 10;
+  box-shadow: var(--shadow-lg);
+  background: var(--color-bg);
+}
+
+/* While a drag is live, iframes must not swallow the pointer stream, and
+   stray text selection just looks broken. */
+.cell-list.is-dragging {
+  user-select: none;
+}
+
+.cell-list.is-dragging iframe {
+  pointer-events: none;
+}
+
+.drag-handle {
+  display: inline-flex;
+  align-items: center;
+  border: 0;
+  background: none;
+  padding: 2px;
+  margin-right: 4px;
+  color: var(--color-neutral-400);
+  cursor: grab;
+  touch-action: none;
+}
+
+.drag-handle:hover,
+.drag-handle:focus-visible {
+  color: var(--color-neutral-800);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}

--- a/jbook/packages/local-client/src/components/cell-list.test.tsx
+++ b/jbook/packages/local-client/src/components/cell-list.test.tsx
@@ -66,6 +66,15 @@ describe('CellList', () => {
     expect(document.querySelectorAll('.add-cell')).toHaveLength(3);
   });
 
+  it('renders a drag handle on every cell', async () => {
+    renderWithStore(<CellList />);
+    await screen.findByTestId('editor');
+
+    expect(
+      screen.getAllByRole('button', { name: /drag to reorder/i })
+    ).toHaveLength(2);
+  });
+
   it('isolates a crashing cell without unmounting its siblings', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(axios.get).mockResolvedValue({

--- a/jbook/packages/local-client/src/components/cell-list.tsx
+++ b/jbook/packages/local-client/src/components/cell-list.tsx
@@ -1,9 +1,23 @@
 import "./cell-list.css";
-import { Fragment, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, Plus } from "lucide-react";
+import {
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { useTypedSelector } from "../hooks/use-typed-selector";
 import { selectCells } from "../state";
-import CellListItem from "./cell-list-item";
+import SortableCell from "./sortable-cell";
 import AddCell from "./add-cell";
 import ExplainerText from "./example-text";
 import { useActions } from "../hooks/use-actions";
@@ -24,11 +38,30 @@ const CellList: React.FC = () => {
     const { order, data } = selectCells(state);
     return order.map((id) => data[id]);
   });
-  const { fetchCells, insertCellAfter } = useActions();
+  const { fetchCells, insertCellAfter, reorderCell } = useActions();
 
   // Don't flash the empty state before the initial fetch has answered.
   const [ready, setReady] = useState(false);
   const [guideOpen, setGuideOpen] = useState(readGuideOpen);
+  // While a drag is live, previews get pointer-events: none — an iframe
+  // under the cursor would otherwise swallow the pointermove stream.
+  const [dragging, setDragging] = useState(false);
+
+  // A small activation distance keeps plain clicks on the grip from starting
+  // a drag; the keyboard sensor makes the handle work with space + arrows.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const onDragEnd = (event: DragEndEvent) => {
+    setDragging(false);
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const toIndex = cells.findIndex((cell) => cell.id === over.id);
+      reorderCell(String(active.id), toIndex);
+    }
+  };
 
   useEffect(() => {
     // bindActionCreators types the bound thunk by its creator, but at runtime
@@ -103,14 +136,24 @@ const CellList: React.FC = () => {
         </button>
       </div>
       {guideOpen && <ExplainerText />}
-      <main className="cell-list">
+      <main className={`cell-list${dragging ? " is-dragging" : ""}`}>
         <AddCell previousCellId={null} />
-        {cells.map((cell, index) => (
-          <Fragment key={cell.id}>
-            <CellListItem cell={cell} index={index} />
-            <AddCell previousCellId={cell.id} />
-          </Fragment>
-        ))}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={() => setDragging(true)}
+          onDragCancel={() => setDragging(false)}
+          onDragEnd={onDragEnd}
+        >
+          <SortableContext
+            items={cells.map((cell) => cell.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {cells.map((cell, index) => (
+              <SortableCell key={cell.id} cell={cell} index={index} />
+            ))}
+          </SortableContext>
+        </DndContext>
       </main>
     </>
   );

--- a/jbook/packages/local-client/src/components/sortable-cell.tsx
+++ b/jbook/packages/local-client/src/components/sortable-cell.tsx
@@ -1,0 +1,41 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Cell } from '../state';
+import CellListItem from './cell-list-item';
+import AddCell from './add-cell';
+
+interface SortableCellProps {
+  cell: Cell;
+  index: number;
+}
+
+// One sortable unit is a cell plus its trailing add-cell rail, so the rail
+// travels with its cell while items shift around during a drag.
+const SortableCell: React.FC<SortableCellProps> = ({ cell, index }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: cell.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`sortable-cell${isDragging ? ' dragging' : ''}`}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+    >
+      <CellListItem
+        cell={cell}
+        index={index}
+        dragHandle={{ ref: setActivatorNodeRef, attributes, listeners }}
+      />
+      <AddCell previousCellId={cell.id} />
+    </div>
+  );
+};
+
+export default SortableCell;

--- a/jbook/packages/local-client/src/state/action-creators.ts
+++ b/jbook/packages/local-client/src/state/action-creators.ts
@@ -3,6 +3,7 @@ export {
   fetchCells,
   insertCellAfter,
   moveCell,
+  reorderCell,
   saveCells,
   updateCell,
 } from './cells-slice';

--- a/jbook/packages/local-client/src/state/cells-slice.test.ts
+++ b/jbook/packages/local-client/src/state/cells-slice.test.ts
@@ -6,6 +6,7 @@ import reducer, {
   fetchCells,
   insertCellAfter,
   moveCell,
+  reorderCell,
   saveCells,
   updateCell,
 } from './cells-slice';
@@ -48,6 +49,28 @@ describe('cells reducers', () => {
     const state = stateWith(cellA, cellB);
     expect(reducer(state, moveCell('a', 'up')).order).toEqual(['a', 'b']);
     expect(reducer(state, moveCell('b', 'down')).order).toEqual(['a', 'b']);
+  });
+
+  it('reorderCell moves a cell to an absolute position in either direction', () => {
+    const cellC: Cell = { id: 'c', type: 'code', content: 'show(3);' };
+    const state = stateWith(cellA, cellB, cellC);
+
+    expect(reducer(state, reorderCell('a', 2)).order).toEqual(['b', 'c', 'a']);
+    expect(reducer(state, reorderCell('c', 0)).order).toEqual(['c', 'a', 'b']);
+  });
+
+  it('reorderCell clamps out-of-range targets and ignores no-ops', () => {
+    const cellC: Cell = { id: 'c', type: 'code', content: 'show(3);' };
+    const state = stateWith(cellA, cellB, cellC);
+
+    expect(reducer(state, reorderCell('a', 99)).order).toEqual(['b', 'c', 'a']);
+    expect(reducer(state, reorderCell('a', -5)).order).toEqual(['a', 'b', 'c']);
+    expect(reducer(state, reorderCell('b', 1)).order).toEqual(['a', 'b', 'c']);
+    expect(reducer(state, reorderCell('nope', 0)).order).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
   });
 
   it('insertCellAfter inserts after the given id', () => {

--- a/jbook/packages/local-client/src/state/cells-slice.ts
+++ b/jbook/packages/local-client/src/state/cells-slice.ts
@@ -88,6 +88,29 @@ const cellsSlice = createSlice({
         return { payload: { id, direction } };
       },
     },
+    // Drag-and-drop reorder: move a cell to an absolute position in the
+    // notebook (moveCell above stays for the one-step arrow buttons).
+    reorderCell: {
+      reducer(
+        state,
+        action: PayloadAction<{ id: string; toIndex: number }>
+      ) {
+        const { id, toIndex } = action.payload;
+        const from = state.order.findIndex((cellId) => cellId === id);
+        if (from < 0) {
+          return;
+        }
+        const to = Math.max(0, Math.min(toIndex, state.order.length - 1));
+        if (to === from) {
+          return;
+        }
+        state.order.splice(from, 1);
+        state.order.splice(to, 0, id);
+      },
+      prepare(id: string, toIndex: number) {
+        return { payload: { id, toIndex } };
+      },
+    },
     insertCellAfter: {
       reducer(
         state,
@@ -142,7 +165,7 @@ const cellsSlice = createSlice({
   },
 });
 
-export const { updateCell, deleteCell, moveCell, insertCellAfter } =
+export const { updateCell, deleteCell, moveCell, reorderCell, insertCellAfter } =
   cellsSlice.actions;
 
 export default cellsSlice.reducer;

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import axios from 'axios';
 import { configureStore } from '@reduxjs/toolkit';
-import { fetchCells, updateCell, deleteCell } from '../cells-slice';
+import {
+  fetchCells,
+  updateCell,
+  deleteCell,
+  reorderCell,
+} from '../cells-slice';
 import { undoableCellsReducer } from '../store';
 import bundlesReducer from '../bundles-slice';
 import { persistMiddleware } from './persist-middleware';
@@ -43,6 +48,15 @@ describe('persist middleware', () => {
     expect(axios.post).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves after a drag reorder', async () => {
+    const store = makeStore();
+
+    store.dispatch(reorderCell('a', 1));
+    await vi.advanceTimersByTimeAsync(PERSIST_SAVE_DEBOUNCE_MS);
+
     expect(axios.post).toHaveBeenCalledTimes(1);
   });
 

--- a/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
+++ b/jbook/packages/local-client/src/state/middlewares/persist-middleware.ts
@@ -4,13 +4,20 @@ import {
   deleteCell,
   insertCellAfter,
   moveCell,
+  reorderCell,
   saveCells,
   updateCell,
 } from '../cells-slice';
 import type { AppDispatch } from '../store';
 import { PERSIST_SAVE_DEBOUNCE_MS } from '../../constants';
 
-const isCellEdit = isAnyOf(updateCell, deleteCell, moveCell, insertCellAfter);
+const isCellEdit = isAnyOf(
+  updateCell,
+  deleteCell,
+  moveCell,
+  reorderCell,
+  insertCellAfter
+);
 
 // Undo/redo restore a different notebook state and must be persisted too.
 const isPersistTrigger = (action: unknown): boolean =>

--- a/jbook/packages/local-client/src/state/store.ts
+++ b/jbook/packages/local-client/src/state/store.ts
@@ -5,6 +5,7 @@ import cellsReducer, {
   deleteCell,
   insertCellAfter,
   moveCell,
+  reorderCell,
   updateCell,
 } from './cells-slice';
 import bundlesReducer from './bundles-slice';
@@ -22,6 +23,7 @@ export const undoableCellsReducer = undoable(cellsReducer, {
     updateCell.type,
     deleteCell.type,
     moveCell.type,
+    reorderCell.type,
     insertCellAfter.type,
   ]),
   // Keep the internal snapshot in sync when filtered actions (like the

--- a/jbook/packages/local-client/src/state/undo-redo.test.ts
+++ b/jbook/packages/local-client/src/state/undo-redo.test.ts
@@ -7,6 +7,7 @@ import {
   fetchCells,
   insertCellAfter,
   moveCell,
+  reorderCell,
   updateCell,
 } from './cells-slice';
 import { Cell } from './cell';
@@ -63,6 +64,15 @@ describe('notebook undo/redo', () => {
   it('undo reverts a move', () => {
     const store = makeStore();
     store.dispatch(moveCell('b', 'up'));
+    expect(present(store).order).toEqual(['b', 'a']);
+
+    store.dispatch(ActionCreators.undo());
+    expect(present(store).order).toEqual(['a', 'b']);
+  });
+
+  it('undo reverts a drag reorder', () => {
+    const store = makeStore();
+    store.dispatch(reorderCell('a', 1));
     expect(present(store).order).toEqual(['b', 'a']);
 
     store.dispatch(ActionCreators.undo());


### PR DESCRIPTION
## Summary

Every cell header gains a grip handle — drag it to move the cell anywhere in the notebook. The one-step arrow buttons remain.

### State
- New `reorderCell(id, toIndex)` reducer moves a cell to an absolute position (clamped, no-op guarded). Wired into the redux-undo include filter — **a drag is one undo step** — and the persist middleware, so the new order saves to `notebook.js` like any other edit.

### UI (built on @dnd-kit/core + sortable)
- A cell and its trailing add-cell rail form **one sortable unit**, so the rails travel with their cells while items shift mid-drag.
- **Only the handle activates a drag** (4 px activation distance, so plain clicks don't) — selecting code in Monaco and clicking the preview are untouched.
- While a drag is live, the list disables iframe `pointer-events` so previews can't swallow the pointer stream.
- The handle is **keyboard-accessible** (space to lift, arrows to move, space to drop) and carries dnd-kit's sortable ARIA attributes (`aria-roledescription="sortable"`, screen-reader instructions via `aria-describedby`).
- Adds `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` as local-client runtime deps (bundled by Vite — no install-time change for users).

## Verification
- 92 local-client tests green, 5 new: reorder semantics in both directions, clamping/no-op/unknown-id, undo of a drag, persistence trigger, handle rendering.
- Verified in the production build by dispatching native-shaped `PointerEvent`s through the real handler → sensor → reducer path (the browser-automation pane's synthesized drags lack the pointer properties dnd-kit's sensors check, so this is the same code path a real mouse takes): one drag produced exactly the expected order, the `is-dragging` state applied, the order persisted to `notebook.js`, and the undo button reverted the drag as a single step.

Release note: ships as 3.7.0 (local-client + cli bump).