### PR TITLE
Prepare the 3.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.7.0 — 2026-08-02
 
 ### Added
 - **Drag-to-reorder cells.** Every cell header has a grip handle — drag it to move the cell anywhere in the notebook (the one-step arrow buttons remain). The handle is keyboard-accessible (space to lift, arrows to move, space to drop), a drag counts as one undo step, and the new order saves to `notebook.js` like any other edit. Only the handle starts a drag, so selecting code or clicking in the preview is unaffected.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.7
+
+- **Drag cells to reorder them.** Grab the grip handle in any cell's header and drop the cell where you want it — or use it from the keyboard (space to lift, arrows to move, space to drop). A drag is a single undo step, and the new order saves like any other edit. The one-step arrow buttons are still there.
+
 ## What's new in 3.6
 
 - **Unchanged cells don't rebundle.** Bundle results are now cached, so reopening an unchanged notebook is instant, and undo/redo, moving a cell and moving it back, and **Run all** skip esbuild for anything already bundled — those cells say "Bundled from cache". **Clear cache** resets both the bundle and npm module caches.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.6.0"
+  "version": "3.7.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14567,7 +14567,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15096,7 +15096,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -50,6 +50,10 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## What's new in 3.7
+
+- **Drag cells to reorder them.** Grab the grip handle in any cell's header and drop the cell where you want it — or use it from the keyboard (space to lift, arrows to move, space to drop). A drag is a single undo step, and the new order saves like any other edit. The one-step arrow buttons are still there.
+
 ## What's new in 3.6
 
 - **Unchanged cells don't rebundle.** Bundle results are now cached, so reopening an unchanged notebook is instant, and undo/redo, moving a cell and moving it back, and **Run all** skip esbuild for anything already bundled — those cells say "Bundled from cache". **Clear cache** resets both the bundle and npm module caches.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.7.0, carrying [PR #39](https://github.com/dannysarco/code-editor/pull/39)'s drag-to-reorder cells.

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.7.0; local-api and types remain 3.0.0, covered by `^3.0.0` ranges. `lerna.json` syncs to 3.7.0.
- Changelog's Unreleased section becomes **3.7.0 — 2026-08-02**.
- "What's new in 3.7" sections added to the root and cli READMEs.

## Verification
- 111 tests green across the workspace (cli 9, local-api 10, local-client 92).
- Both packages build; the rebuilt CLI bundle reports 3.7.0.
- `npm pack --dry-run`: cli 588.9 kB / 3 files; local-client 7.9 MB / 123 files.

After merge: publish **both** `@my-scrapbook/local-client` and `my-scrapbook` (two OTP prompts) from a freshly pulled main checkout, then tag `v3.7.0`.