### PR TITLE
Publish from CI with npm provenance; add CI and npm badges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish
+
+# Publishes every package whose version isn't on the registry yet, with npm
+# provenance attestations. Runs when a release tag is pushed (the release
+# flow: merge the release-prep PR, then push the vX.Y.Z tag), or manually.
+#
+# Auth is npm "trusted publishing" (OIDC): each package on npmjs.com is
+# configured to trust this repo + workflow file, so no npm token is stored in
+# the repo and the user's 2FA stays untouched. Provenance requires the OIDC
+# id-token permission below.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: jbook/package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs a recent npm (>= 11.5.1 for OIDC exchange).
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install
+        run: npm ci
+        working-directory: jbook
+
+      - name: Test
+        run: npm test
+        working-directory: jbook
+
+      # Dependency order: types -> local-api -> local-client -> cli. Each
+      # package's prepublishOnly script builds it. Versions already on the
+      # registry are skipped, so a release that bumps only some packages
+      # publishes only those.
+      - name: Publish packages with provenance
+        run: |
+          for dir in types local-api local-client cli; do
+            pkg="jbook/packages/$dir"
+            name=$(node -p "require('./$pkg/package.json').name")
+            version=$(node -p "require('./$pkg/package.json').version")
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version already on the registry — skipping"
+            else
+              echo "Publishing $name@$version"
+              (cd "$pkg" && npm publish --provenance)
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Automated npm publishing with provenance.** A new `publish.yml` GitHub Actions workflow runs on release tags (`v*`): it tests the workspace and publishes every package whose version isn't on the registry yet with `npm publish --provenance`, using npm trusted publishing (OIDC) — no npm token stored anywhere, and published versions get the registry's verified provenance attestation. CI and npm version badges added to the READMEs.
+
 ## 3.7.0 — 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Getting Started with My Scrapbook - a dynamic coding environment.
 
+[![CI](https://github.com/dannysarco/code-editor/actions/workflows/ci.yml/badge.svg?branch=live)](https://github.com/dannysarco/code-editor/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/my-scrapbook)](https://www.npmjs.com/package/my-scrapbook)
+
 ## What is My Scrapbook, and what does it do?
 
 - It's a full-featured in-browser IDE and markdown editor for documentation.

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -1,5 +1,8 @@
 # My Scrapbook - a dynamic coding environment.
 
+[![CI](https://github.com/dannysarco/code-editor/actions/workflows/ci.yml/badge.svg?branch=live)](https://github.com/dannysarco/code-editor/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/my-scrapbook)](https://www.npmjs.com/package/my-scrapbook)
+
 ## What is My Scrapbook, and what does it do?
 
 - It's a full-featured in-browser IDE and markdown editor for documentation.


### PR DESCRIPTION
## Summary

Closes out the npm trust items: releases publish from GitHub Actions with provenance attestations, and both READMEs carry CI + npm version badges.

### Publish workflow (`.github/workflows/publish.yml`)
- Triggers on a `v*` tag push (or manual dispatch).
- Installs, runs the **full workspace test suite** as a release gate.
- Walks the four packages in dependency order (types → local-api → local-client → cli) and publishes **only versions not yet on the registry** with `npm publish --provenance` — so a release bumping only some packages publishes only those, and re-runs are safe no-ops.
- Auth is **npm trusted publishing (OIDC)**: no npm token stored in the repo, nothing that bypasses account 2FA (which npm is restricting anyway). Provenance gives the npm page the verified "built and signed on GitHub Actions" check.

### Badges
- CI status (`live` branch) + npm version badges on the root and cli READMEs (the npm page picks them up at the next publish). Both badge URLs verified live.

## Verification
- Workflow YAML validated; `id-token: write` permission in place.
- Skip logic dry-run against the real registry: all four current versions (`types`/`local-api` 3.0.0, `local-client`/`cli` 3.7.0) correctly report already-published — a tag push today is a clean no-op.

## Required one-time setup (npm account owner)
For each of `my-scrapbook`, `@my-scrapbook/local-client`, `@my-scrapbook/local-api`, `@my-scrapbook/types` on npmjs.com: **Settings → Trusted Publisher → GitHub Actions**, org/user `dannysarco`, repository `code-editor`, workflow filename `publish.yml`, environment blank.

## New release flow after merge
Merge the release-prep PR → push the `vX.Y.Z` tag → CI tests and publishes with provenance. No local `npm publish`, no OTP clicks. The first tagged release proves the pipeline end-to-end.