### PR TITLE
Prepare the 3.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 3.7.1 — 2026-08-02
+
+First release published by CI. No functional changes: the npm package README gains the CI and version badges, and the release itself carries the provenance attestation introduced below.
 
 ### Added
 - **Automated npm publishing with provenance.** A new `publish.yml` GitHub Actions workflow runs on release tags (`v*`): it tests the workspace and publishes every package whose version isn't on the registry yet with `npm publish --provenance`, using npm trusted publishing (OIDC) — no npm token stored anywhere, and published versions get the registry's verified provenance attestation. CI and npm version badges added to the READMEs.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.7.0"
+  "version": "3.7.1"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14567,7 +14567,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",


### PR DESCRIPTION
Patch release prep — and the live test of the new CI publish pipeline from [PR #41](https://github.com/dannysarco/code-editor/pull/41).

- `my-scrapbook` → 3.7.1: no functional changes; the npm package README gains the CI + version badges. local-client stays 3.7.0, local-api/types stay 3.0.0 (all three get skipped by the workflow's already-published check — which is part of what this run tests). `lerna.json` syncs to 3.7.1.
- Changelog: Unreleased becomes **3.7.1 — 2026-08-02**.

## Verification
- 111 tests green across the workspace; CLI bundle reports 3.7.1.

## After merge — the pipeline test
Push the `v3.7.1` tag. The Publish workflow should: run the test suite, skip types/local-api/local-client, and publish `my-scrapbook@3.7.1` with provenance via trusted publishing. No local publish, no OTP.