### PR TITLE
Fix CI publish: build local-api before bundling the cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,15 @@ jobs:
         run: npm test
         working-directory: jbook
 
+      # The cli bundle resolves @my-scrapbook/local-api through the workspace
+      # symlink to its dist output. When local-api itself is skipped (already
+      # published), its prepublishOnly never runs — so build it explicitly or
+      # the cli's esbuild step fails with "could not resolve". (types builds
+      # via its prepare script during npm ci.)
+      - name: Build workspace dependencies
+        run: npx tsc
+        working-directory: jbook/packages/local-api
+
       # Dependency order: types -> local-api -> local-client -> cli. Each
       # package's prepublishOnly script builds it. Versions already on the
       # registry are skipped, so a release that bumps only some packages


### PR DESCRIPTION
The v3.7.1 pipeline run failed at the cli's `prepublishOnly`: esbuild `Could not resolve "@my-scrapbook/local-api"`.

**Root cause:** the cli bundle resolves local-api through the workspace symlink to its **dist output** — but the workflow correctly skipped publishing local-api (already on the registry), so its `prepublishOnly` never ran and nothing built it on the fresh runner. Locally this never surfaced because dev builds always leave `dist/` behind; `ci.yml` has an explicit build step this workflow lacked.

**Fix:** an explicit "Build workspace dependencies" step (`npx tsc` in local-api) before the publish loop. types builds via its `prepare` script during `npm ci`; local-client isn't needed at cli bundle time (its `require.resolve` reference stays unresolved by design, warning only).

Everything else in [the failed run](https://github.com/dannysarco/code-editor/actions/runs/30762159878) behaved: test gate green, and types/local-api/local-client were correctly skipped as already-published.

After merge: I'll move the `v3.7.1` tag to the fix commit and the tag push re-runs the pipeline.