### PR TITLE
Fix CI publish: drop registry-url so npm's OIDC exchange runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Deliberately no registry-url: setting it makes setup-node write an
+      # .npmrc with _authToken=${NODE_AUTH_TOKEN}, and the presence of a
+      # (empty) token makes npm skip the OIDC trusted-publishing exchange —
+      # the publish then fails with a masked E404. With no token configured,
+      # npm detects the Actions OIDC environment and exchanges automatically.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: jbook/package-lock.json
-          registry-url: https://registry.npmjs.org
 
       # Trusted publishing needs a recent npm (>= 11.5.1 for OIDC exchange).
       - name: Update npm


### PR DESCRIPTION
Second pipeline attempt ([run](https://github.com/dannysarco/code-editor/actions/runs/30762285131)) got much further: build fix worked, tarball packed, **provenance statement signed and published to the sigstore transparency log** — then the registry PUT failed with `E404` (npm's masked permission error).

**Cause:** `setup-node`'s `registry-url` option writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`. No token is set — that's the point of trusted publishing — but the presence of the token config makes npm **skip the OIDC exchange** and PUT with empty credentials. The documented trusted-publishing setup is: configure no token at all, and npm ≥ 11.5.1 detects the Actions OIDC environment and exchanges a short-lived credential automatically.

**Fix:** remove `registry-url` (registry defaults to registry.npmjs.org).

After merge: move the `v3.7.1` tag once more — third run should go green end to end.