### PR TITLE
Pin npm@11 in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,9 +34,13 @@ jobs:
           cache: npm
           cache-dependency-path: jbook/package-lock.json
 
-      # Trusted publishing needs a recent npm (>= 11.5.1 for OIDC exchange).
+      # Trusted publishing needs npm >= 11.5.1 for the OIDC exchange —
+      # pinned to 11 because npm 12.0.x fails the exchange with "OIDC token
+      # exchange error - package not found" (verified: 12.0.2 fails, 11
+      # publishes; this is what broke the first v3.7.1 pipeline runs).
+      # Revisit the pin when npm 12 fixes the regression.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Final fix from the v3.7.1 pipeline shakedown — and the pipeline **works**: `my-scrapbook@3.7.1` is published with a verified provenance attestation (`npm audit signatures` confirms; sigstore transparency log entry linked in [the green run](https://github.com/dannysarco/code-editor/actions/runs/30763444169)).

**Root cause of the last failures:** an npm 12.0.x regression. Differential test on the same commit and same trusted-publisher config: npm 12.0.2 fails the OIDC exchange with `OIDC token exchange error - package not found`; npm 11 exchanges (`POST 201 …/oidc/token/exchange/package/my-scrapbook`) and publishes. So: pin `npm@11` instead of `npm@latest`, with a comment to revisit when npm 12 fixes it.

Full shakedown ledger (three real bugs found and fixed by the test):
1. Missing local-api build before the cli bundle ([#43](https://github.com/dannysarco/code-editor/pull/43))
2. `registry-url` writing an empty-token `.npmrc` that suppresses OIDC ([#44](https://github.com/dannysarco/code-editor/pull/44))
3. npm 12 exchange regression (this PR) — plus one config fix on npmjs.com (workflow filename must be `publish.yml`, not the full path).

After merge I'll delete the debug branch; no re-publish needed — 3.7.1 is live.