### PR TITLE
Prepare the 3.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 3.7.2 — 2026-08-02
+
+No functional changes: ships the refreshed npm-page README below.
 
 ### Changed
 - **README examples and screenshots refreshed.** The sample explainer now describes the current feature set (TypeScript, the console panel, drag-to-reorder, offline packages) and loses a long-standing typo; the code samples are a TypeScript task-list component (interface + generics + `console.log`) and an axios + bulma cell that fetches and renders live data. Screenshots regenerated against the current UI — JS/TS labels, grip handles, and console panels included. Every sample was verified running in the app before being captured.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.7.1"
+  "version": "3.7.2"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14567,7 +14567,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",


### PR DESCRIPTION
Patch release: ships [PR #46](https://github.com/dannysarco/code-editor/pull/46)'s refreshed README examples and screenshots to the npm page. No functional changes.

- `my-scrapbook` → 3.7.2; local-client stays 3.7.0, local-api/types stay 3.0.0 (skipped by the publish workflow). `lerna.json` syncs.
- Changelog: Unreleased becomes **3.7.2 — 2026-08-02**.

## Verification
- 111 tests green across the workspace; CLI bundle reports 3.7.2.

After merge: push the `v3.7.2` tag and CI publishes with provenance — second run of the settled pipeline (npm@11 pin from [#45](https://github.com/dannysarco/code-editor/pull/45) now in `live`).