### PR TITLE
Bump actions/checkout and actions/setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
       run:
         working-directory: jbook
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      # Deliberately no registry-url: setting it makes setup-node write an
-      # .npmrc with _authToken=${NODE_AUTH_TOKEN}, and the presence of a
-      # (empty) token makes npm skip the OIDC trusted-publishing exchange —
-      # the publish then fails with a masked E404. With no token configured,
-      # npm detects the Actions OIDC environment and exchanges automatically.
-      - uses: actions/setup-node@v4
+      # Deliberately no registry-url: we publish to the default registry, and
+      # npm >= 11.5.1 detects the Actions OIDC environment and exchanges
+      # automatically. Before setup-node v7, setting registry-url also broke
+      # the exchange (it exported a dummy NODE_AUTH_TOKEN, making npm skip
+      # OIDC and fail with a masked E404); v7 fixed that upstream, but there
+      # is still no reason to set it here.
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
GitHub Actions now annotates every run with a Node.js 20 deprecation warning for `actions/checkout@v4` and `actions/setup-node@v4`. This bumps both to their current major, **v7** (Node 24-based), in `ci.yml` and `publish.yml`.

## Breaking-change review
- **checkout v7** blocks fork-PR checkout for `pull_request_target`/`workflow_run` triggers — not used here (CI runs on `push`/`pull_request`, publish on tag push / manual dispatch).
- **checkout v6** moved persisted credentials under `$RUNNER_TEMP` (needs runner ≥ v2.329.0) — fine on GitHub-hosted runners.
- **setup-node v6** limited automatic caching to npm — moot, `cache: npm` is explicit in both workflows.
- **setup-node v7** migrated to ESM and removed the dummy `NODE_AUTH_TOKEN` export.

## publish.yml comments
- The "deliberately no registry-url" guidance still holds: we publish to the default registry, where npm ≥ 11.5.1 auto-detects the Actions OIDC environment. The comment's *rationale* was v4-specific (the dummy-token export that broke the exchange was fixed upstream in setup-node v7), so it's been rewritten to stay accurate.
- The npm@11 pin comment (npm 12 OIDC-exchange regression) is independent of this bump and unchanged.

Note: the publish workflow itself only runs on tag push, so its v7 path gets exercised for real at the next release.