### PR TITLE
Disable dependency caching in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,15 @@ jobs:
       # (empty) token makes npm skip the OIDC trusted-publishing exchange —
       # the publish then fails with a masked E404. With no token configured,
       # npm detects the Actions OIDC environment and exchanges automatically.
+      #
+      # Deliberately no dependency caching either: this job holds id-token
+      # write for trusted publishing, and a poisoned npm cache could run
+      # attacker-controlled code with access to the OIDC token (per the
+      # setup-node trusted-publishing docs). Publish runs are rare, so the
+      # full npm ci is a fine trade.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: npm
-          cache-dependency-path: jbook/package-lock.json
 
       # Trusted publishing needs npm >= 11.5.1 for the OIDC exchange —
       # pinned to 11 because npm 12.0.x fails the exchange with "OIDC token


### PR DESCRIPTION
## Why

The publish job holds `id-token: write` for npm trusted publishing (OIDC). The actions/setup-node trusted-publishing docs ([docs/advanced-usage.md](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md)) recommend disabling dependency caching in publishing workflows: a poisoned cache may expose credentials — including the OIDC token — to attacker-controlled code.

Publish runs only happen on release tags (or manual dispatch), so the slower uncached `npm ci` is an acceptable trade.

## What changed

- Removed `cache: npm` and `cache-dependency-path` from the setup-node step in `publish.yml`, with a comment explaining why caching is deliberately off.
- `ci.yml` keeps its caching — it doesn't hold `id-token: write`.

## Notes

- `package-manager-cache: false` is **not** needed: jbook/package.json has no `packageManager` or `devEngines` field, and the workflow is on `setup-node@v4`, where that input doesn't exist and caching only ever activates via the explicit `cache:` input. Removing the two lines fully disables caching.
- No behavior change to the publish itself — the no-`registry-url` OIDC setup and the npm@11 pin are untouched.