### PR TITLE
Add static HTML export: share a notebook as one self-contained live page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Static HTML export.** An **Export HTML** button in the notebook header downloads the notebook as one self-contained `notebook.html`: text cells as rendered markdown, code cells with their source behind a collapsible toggle plus a live preview — each cell's bundled code executes in a sandboxed iframe with the same shell the app uses (shared, not copied), console output included. The file makes zero network requests, so it works offline and can be shared with anyone. Exporting bundles through the same cache as the app, so an already-bundled notebook exports instantly; cells that fail to bundle export their error message where the preview would be.
+
 ## 3.8.0 — 2026-08-02
 
 Dependency and release-hygiene refresh; no notebook features.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## Share a notebook as a live HTML page
+
+- Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
+- The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
+- Each code cell's source is included too, behind a collapsible **Source** toggle.
+
 ## What's new in 3.8
 
 - **Node 20 or newer is now required** (Node 18 reached end of life). Under the hood the CLI's dependencies moved to current majors — express 5 and commander 14 — so a command with stray extra arguments now fails with a clear error instead of being silently ignored.

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -53,6 +53,12 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## Share a notebook as a live HTML page
+
+- Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
+- The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
+- Each code cell's source is included too, behind a collapsible **Source** toggle.
+
 ## What's new in 3.8
 
 - **Node 20 or newer is now required** (Node 18 reached end of life). Under the hood the CLI's dependencies moved to current majors — express 5 and commander 14 — so a command with stray extra arguments now fails with a clear error instead of being silently ignored.

--- a/jbook/packages/local-client/src/bundler/bundle-with-cache.ts
+++ b/jbook/packages/local-client/src/bundler/bundle-with-cache.ts
@@ -1,0 +1,22 @@
+import type { BundleResult } from '@my-scrapbook/types';
+import bundler from './index';
+import { getCachedBundle, setCachedBundle } from './bundle-cache';
+
+// Cache-aware entry point shared by the bundles slice and the HTML export:
+// serves the stored output when this input was bundled before, and stores
+// the result otherwise. Lives apart from the bundler itself so callers (and
+// tests) can treat "run esbuild" and "consult the cache" as separate seams.
+export const bundleWithCache = async (
+  cellId: string,
+  input: string
+): Promise<BundleResult & { durationMs?: number; cached: boolean }> => {
+  const cached = await getCachedBundle(cellId, input);
+  if (cached) {
+    return { ...cached, cached: true };
+  }
+
+  const started = performance.now();
+  const result = await bundler(input);
+  await setCachedBundle(cellId, input, result);
+  return { ...result, durationMs: performance.now() - started, cached: false };
+};

--- a/jbook/packages/local-client/src/components/notebook-header.tsx
+++ b/jbook/packages/local-client/src/components/notebook-header.tsx
@@ -4,13 +4,12 @@ import { useTypedSelector } from '../hooks/use-typed-selector';
 import { useActions } from '../hooks/use-actions';
 import { selectCells } from '../state';
 import { cumulativeCodeFor } from '../hooks/use-cumulative-code';
-import { PERSIST_SAVE_DEBOUNCE_MS } from '../constants';
+import { PERSIST_SAVE_DEBOUNCE_MS, NOTEBOOK_FILENAME } from '../constants';
+import { exportNotebookHtml } from '../export/export-notebook';
 import OfflineStatus from './offline-status';
 import UndoRedoBar from './undo-redo-bar';
 
-// The client edits whatever file local-api was started with; the API does
-// not expose the name, so the header shows the CLI's default.
-const NOTEBOOK_FILENAME = 'notebook.js';
+const EXPORT_FILENAME = NOTEBOOK_FILENAME.replace(/\.[^.]*$/, '') + '.html';
 
 const formatTime = (date: Date) =>
   date.toLocaleTimeString([], {
@@ -56,6 +55,28 @@ const NotebookHeader: React.FC = () => {
     }
   };
 
+  const [exportState, setExportState] = useState<
+    'idle' | 'exporting' | 'failed'
+  >('idle');
+
+  const onExportHtml = async () => {
+    setExportState('exporting');
+    try {
+      await exportNotebookHtml(
+        present.order.map((id) => present.data[id]),
+        EXPORT_FILENAME
+      );
+      setExportState('idle');
+    } catch (err) {
+      // Bundler errors come back through the result, so reaching here is
+      // unexpected (e.g. esbuild failed to initialize while offline on a
+      // first visit). Keep the notebook usable and say the export failed.
+      console.error('HTML export failed:', err);
+      setExportState('failed');
+      setTimeout(() => setExportState('idle'), 3000);
+    }
+  };
+
   return (
     <header className="notebook-header">
       <span className="brand-mark" aria-hidden="true" />
@@ -70,6 +91,17 @@ const NotebookHeader: React.FC = () => {
       <span className="header-spacer" />
       <OfflineStatus />
       <UndoRedoBar />
+      <button
+        className="btn btn-secondary export-html"
+        onClick={onExportHtml}
+        disabled={exportState === 'exporting'}
+      >
+        {exportState === 'exporting'
+          ? 'Exporting…'
+          : exportState === 'failed'
+          ? 'Export failed'
+          : 'Export HTML'}
+      </button>
       <button className="btn btn-primary run-all" onClick={onRunAll}>
         Run all
       </button>

--- a/jbook/packages/local-client/src/components/preview-shell.ts
+++ b/jbook/packages/local-client/src/components/preview-shell.ts
@@ -1,0 +1,77 @@
+// The document loaded into every preview iframe, in the app and in exported
+// HTML alike (the export embeds this string, so both render cell output with
+// exactly the same runtime). The shell installs its listeners, then reports
+// ready to the parent; the parent posts the bundled code exactly once, on
+// that signal. Console calls and runtime errors are forwarded to the parent
+// as messages.
+export const PREVIEW_SHELL_HTML = `
+    <html>
+      <head>
+        <style>html { background-color: white; }</style>
+      </head>
+      <body>
+        <div id="root"></div>
+        <script>
+          // Console arguments can hold anything (cyclic objects, functions,
+          // DOM nodes) so they can't cross postMessage as-is; flatten each to
+          // a string on this side of the boundary.
+          const serialize = (value) => {
+            if (typeof value === 'string') return value;
+            if (value instanceof Error) return String(value);
+            if (typeof value === 'object' && value !== null) {
+              const seen = new WeakSet();
+              try {
+                const json = JSON.stringify(value, (key, v) => {
+                  if (typeof v === 'object' && v !== null) {
+                    if (seen.has(v)) return '[Circular]';
+                    seen.add(v);
+                  }
+                  if (typeof v === 'function') return String(v);
+                  if (typeof v === 'bigint') return v.toString() + 'n';
+                  return v;
+                });
+                if (json !== undefined) return json;
+              } catch (err) {}
+            }
+            return String(value);
+          };
+
+          ['log', 'info', 'warn', 'error', 'debug'].forEach((level) => {
+            const original = console[level].bind(console);
+            console[level] = (...args) => {
+              original(...args);
+              window.parent.postMessage({
+                source: 'preview-console',
+                level,
+                text: args.map(serialize).join(' '),
+              }, '*');
+            };
+          });
+
+          const handleError = (err) => {
+            const root = document.querySelector('#root');
+            root.innerHTML = '<div style="color: red;"><h4>Runtime Error</h4>' + err + '</div>';
+            console.error(err);
+          };
+
+          window.addEventListener('error', (event) => {
+            event.preventDefault();
+            handleError(event.error);
+          });
+
+          window.addEventListener('message', (event) => {
+            try {
+              eval(event.data);
+            } catch (err) {
+              handleError(err);
+            }
+          }, false);
+
+          // Everything is installed; tell the parent this document can accept
+          // code. Posting on a fixed timer instead used to drop the bundle
+          // whenever the iframe loaded slower than the delay.
+          window.parent.postMessage({ source: 'preview-ready' }, '*');
+        </script>
+      </body>
+    </html>
+  `;

--- a/jbook/packages/local-client/src/components/preview.tsx
+++ b/jbook/packages/local-client/src/components/preview.tsx
@@ -1,6 +1,7 @@
 import './preview.css';
 import { useRef, useEffect, useState } from 'react';
 import { MAX_CONSOLE_ENTRIES } from '../constants';
+import { PREVIEW_SHELL_HTML } from './preview-shell';
 
 interface PreviewProps {
   code: string;
@@ -14,77 +15,6 @@ interface ConsoleEntry {
   text: string;
 }
 
-const html = `
-    <html>
-      <head>
-        <style>html { background-color: white; }</style>
-      </head>
-      <body>
-        <div id="root"></div>
-        <script>
-          // Console arguments can hold anything (cyclic objects, functions,
-          // DOM nodes) so they can't cross postMessage as-is; flatten each to
-          // a string on this side of the boundary.
-          const serialize = (value) => {
-            if (typeof value === 'string') return value;
-            if (value instanceof Error) return String(value);
-            if (typeof value === 'object' && value !== null) {
-              const seen = new WeakSet();
-              try {
-                const json = JSON.stringify(value, (key, v) => {
-                  if (typeof v === 'object' && v !== null) {
-                    if (seen.has(v)) return '[Circular]';
-                    seen.add(v);
-                  }
-                  if (typeof v === 'function') return String(v);
-                  if (typeof v === 'bigint') return v.toString() + 'n';
-                  return v;
-                });
-                if (json !== undefined) return json;
-              } catch (err) {}
-            }
-            return String(value);
-          };
-
-          ['log', 'info', 'warn', 'error', 'debug'].forEach((level) => {
-            const original = console[level].bind(console);
-            console[level] = (...args) => {
-              original(...args);
-              window.parent.postMessage({
-                source: 'preview-console',
-                level,
-                text: args.map(serialize).join(' '),
-              }, '*');
-            };
-          });
-
-          const handleError = (err) => {
-            const root = document.querySelector('#root');
-            root.innerHTML = '<div style="color: red;"><h4>Runtime Error</h4>' + err + '</div>';
-            console.error(err);
-          };
-
-          window.addEventListener('error', (event) => {
-            event.preventDefault();
-            handleError(event.error);
-          });
-
-          window.addEventListener('message', (event) => {
-            try {
-              eval(event.data);
-            } catch (err) {
-              handleError(err);
-            }
-          }, false);
-
-          // Everything is installed; tell the parent this document can accept
-          // code. Posting on a fixed timer instead used to drop the bundle
-          // whenever the iframe loaded slower than the delay.
-          window.parent.postMessage({ source: 'preview-ready' }, '*');
-        </script>
-      </body>
-    </html>
-  `;
 
 const Preview: React.FC<PreviewProps> = ({ code, err }) => {
   const iframe = useRef<any>();
@@ -103,7 +33,7 @@ const Preview: React.FC<PreviewProps> = ({ code, err }) => {
     // The iframe deliberately has no srcDoc attribute in JSX: this assignment
     // is the only load, so exactly one document fires 'ready' and executes
     // the code. (Assigning srcdoc always reloads, even with the same value.)
-    iframe.current.srcdoc = html;
+    iframe.current.srcdoc = PREVIEW_SHELL_HTML;
   }, [code]);
 
   useEffect(() => {

--- a/jbook/packages/local-client/src/constants.ts
+++ b/jbook/packages/local-client/src/constants.ts
@@ -22,3 +22,7 @@ export const UNDO_HISTORY_LIMIT = 50;
 // emit thousands of messages per second; keeping only the newest N bounds
 // both memory and re-render cost while still showing where the output ended.
 export const MAX_CONSOLE_ENTRIES = 200;
+
+// The client edits whatever file local-api was started with; the API does
+// not expose the name, so the header and exports use the CLI's default.
+export const NOTEBOOK_FILENAME = 'notebook.js';

--- a/jbook/packages/local-client/src/export/export-html.test.ts
+++ b/jbook/packages/local-client/src/export/export-html.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { buildExportHtml, ExportCell } from './export-html';
+
+const exportedAt = new Date(2026, 7, 2, 12, 0, 0);
+
+const textCell = (html: string): ExportCell => ({ type: 'text', html });
+const codeCell = (overrides: Partial<Extract<ExportCell, { type: 'code' }>> = {}): ExportCell => ({
+  type: 'code',
+  id: 'cell-1',
+  source: 'show(1)',
+  bundledCode: 'var show = () => {}; console.log(1);',
+  bundleErr: '',
+  ...overrides,
+});
+
+describe('buildExportHtml', () => {
+  it('produces a full document with cells in order and numbered headers', () => {
+    const html = buildExportHtml(
+      [textCell('<h1>Notes</h1>'), codeCell({ id: 'abc' })],
+      exportedAt
+    );
+
+    expect(html).toMatch(/^<!doctype html>/);
+    expect(html).toContain('<h1>Notes</h1>');
+    expect(html.indexOf('<h1>Notes</h1>')).toBeLessThan(
+      html.indexOf('data-cell="abc"')
+    );
+    expect(html).toContain('<span>01</span><span>TEXT</span>');
+    expect(html).toContain('<span>02</span><span>CODE</span>');
+  });
+
+  it('escapes code cell source so markup in it stays inert', () => {
+    const html = buildExportHtml(
+      [codeCell({ source: 'show(<b>{"</b>"}</b>)' })],
+      exportedAt
+    );
+
+    expect(html).toContain('show(&lt;b&gt;');
+    expect(html).not.toContain('show(<b>');
+  });
+
+  it('embeds bundles so a </script> inside bundled code cannot end the runtime script', () => {
+    const html = buildExportHtml(
+      [codeCell({ bundledCode: 'console.log("</script><script>bad()")' })],
+      exportedAt
+    );
+
+    // The only literal closing tag is the runtime script's own.
+    expect(html.match(/<\/script>/g)).toHaveLength(1);
+    expect(html).toContain('\\u003c/script>');
+  });
+
+  it('sandboxes every preview iframe', () => {
+    const html = buildExportHtml(
+      [codeCell({ id: 'a' }), codeCell({ id: 'b' })],
+      exportedAt
+    );
+
+    const iframes = html.match(/<iframe[^>]*>/g) ?? [];
+    expect(iframes).toHaveLength(2);
+    for (const tag of iframes) {
+      expect(tag).toContain('sandbox="allow-scripts"');
+    }
+  });
+
+  it('shows the bundler error instead of a preview for cells that failed to bundle', () => {
+    const html = buildExportHtml(
+      [codeCell({ bundleErr: 'Unexpected token "<"', bundledCode: '' })],
+      exportedAt
+    );
+
+    expect(html).toContain('Unexpected token &quot;&lt;&quot;');
+    expect(html).not.toContain('<iframe');
+    // No bundle is embedded for a failed cell.
+    expect(html).toContain('var BUNDLES = {};');
+  });
+});

--- a/jbook/packages/local-client/src/export/export-html.ts
+++ b/jbook/packages/local-client/src/export/export-html.ts
@@ -1,0 +1,244 @@
+import { PREVIEW_SHELL_HTML } from '../components/preview-shell';
+import { MAX_CONSOLE_ENTRIES } from '../constants';
+
+// Everything the page builder needs per cell, precomputed by the caller:
+// text cells arrive as rendered markdown, code cells as their source plus
+// the bundled (or failed) output.
+export type ExportCell =
+  | { type: 'text'; html: string }
+  | {
+      type: 'code';
+      id: string;
+      source: string;
+      bundledCode: string;
+      bundleErr: string;
+    };
+
+const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+// Serialized values are embedded inside an inline <script>; a literal "</"
+// (as in a closing </script> tag inside bundled code) would end that script
+// element mid-string, so every "<" is escaped into the JSON string form.
+const embedJson = (value: unknown): string =>
+  JSON.stringify(value).replace(/</g, '\\u003c');
+
+const STYLES = `
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: #f4f2ee;
+    color: #191919;
+    font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+    line-height: 1.55;
+  }
+  .page { max-width: 860px; margin: 0 auto; padding: 32px 24px 64px; }
+  .export-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding-bottom: 18px;
+    margin-bottom: 28px;
+    border-bottom: 2px solid #d9d5cd;
+  }
+  .export-header .brand-mark { width: 14px; height: 14px; background: #e33d2e; }
+  .export-header .brand-name { font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+  .export-header .export-meta { margin-left: auto; font-size: 12px; color: #6f6a62; }
+  .cell { background: #ffffff; border: 1px solid #d9d5cd; margin-bottom: 26px; }
+  .cell-header {
+    display: flex;
+    gap: 10px;
+    padding: 8px 14px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #6f6a62;
+    border-bottom: 1px solid #ece9e3;
+  }
+  .text-cell-body { padding: 6px 18px 14px; }
+  .text-cell-body :first-child { margin-top: 8px; }
+  .text-cell-body pre, .text-cell-body code {
+    background: #f4f2ee;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.92em;
+  }
+  .text-cell-body pre { padding: 10px 12px; overflow-x: auto; }
+  .text-cell-body blockquote { border-left: 3px solid #d9d5cd; margin-left: 0; padding-left: 14px; color: #52504b; }
+  .text-cell-body table { border-collapse: collapse; }
+  .text-cell-body th, .text-cell-body td { border: 1px solid #d9d5cd; padding: 4px 10px; }
+  .text-cell-body img { max-width: 100%; }
+  .code-source summary {
+    cursor: pointer;
+    padding: 8px 14px;
+    font-size: 12px;
+    color: #6f6a62;
+    user-select: none;
+  }
+  .code-source pre {
+    margin: 0;
+    padding: 12px 16px;
+    overflow-x: auto;
+    background: #23241f;
+    color: #f2f1ef;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .preview { border-top: 1px solid #ece9e3; }
+  .preview-frame { resize: vertical; overflow: hidden; height: 240px; min-height: 80px; }
+  .preview-frame iframe { display: block; border: 0; width: 100%; height: 100%; background: #fff; }
+  .preview-error {
+    margin: 0;
+    padding: 12px 16px;
+    color: #b3261e;
+    background: #fdf1f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    white-space: pre-wrap;
+  }
+  .preview-console { border-top: 1px solid #ece9e3; display: none; }
+  .preview-console-title {
+    display: block;
+    padding: 6px 14px 0;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #6f6a62;
+  }
+  .preview-console-body {
+    max-height: 180px;
+    overflow-y: auto;
+    padding: 6px 14px 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+  .preview-console-entry { padding: 1px 0; white-space: pre-wrap; }
+  .preview-console-warn { color: #8a6d00; }
+  .preview-console-error { color: #b3261e; }
+  .export-footer { font-size: 12px; color: #6f6a62; }
+  noscript { display: block; padding: 12px 16px; color: #b3261e; }
+`;
+
+// The script that brings the exported page's previews to life. It mirrors
+// what the app's Preview component does: load the shared shell into each
+// iframe, post the cell's bundled code when the shell reports ready, and
+// render forwarded console messages under the frame. Written in plain,
+// pre-ES2020 JS since it ships to whatever browser opens the file.
+const runtimeScript = (
+  shellJson: string,
+  bundlesJson: string
+): string => `
+  var SHELL = ${shellJson};
+  var BUNDLES = ${bundlesJson};
+  var frames = document.querySelectorAll('iframe[data-cell]');
+
+  frames.forEach(function (frame) {
+    frame.srcdoc = SHELL;
+  });
+
+  var frameFor = function (source) {
+    for (var i = 0; i < frames.length; i++) {
+      if (frames[i].contentWindow === source) return frames[i];
+    }
+    return null;
+  };
+
+  window.addEventListener('message', function (event) {
+    var frame = frameFor(event.source);
+    if (!frame || !event.data) return;
+
+    if (event.data.source === 'preview-ready') {
+      frame.contentWindow.postMessage(BUNDLES[frame.getAttribute('data-cell')], '*');
+      return;
+    }
+
+    if (event.data.source === 'preview-console') {
+      var cell = frame.closest('.cell');
+      var panel = cell.querySelector('.preview-console');
+      var body = cell.querySelector('.preview-console-body');
+      var entry = document.createElement('div');
+      entry.className = 'preview-console-entry preview-console-' + event.data.level;
+      entry.textContent = String(event.data.text);
+      body.appendChild(entry);
+      while (body.children.length > ${MAX_CONSOLE_ENTRIES}) {
+        body.removeChild(body.firstChild);
+      }
+      panel.style.display = 'block';
+      body.scrollTop = body.scrollHeight;
+    }
+  });
+`;
+
+const cellNumber = (index: number): string =>
+  String(index + 1).padStart(2, '0');
+
+export const buildExportHtml = (
+  cells: ExportCell[],
+  exportedAt: Date
+): string => {
+  const bundles: Record<string, string> = {};
+  const sections = cells.map((cell, index) => {
+    const header = `<div class="cell-header"><span>${cellNumber(
+      index
+    )}</span><span>${cell.type === 'text' ? 'TEXT' : 'CODE'}</span></div>`;
+
+    if (cell.type === 'text') {
+      return `<section class="cell">${header}<div class="text-cell-body">${cell.html}</div></section>`;
+    }
+
+    const source = `<details class="code-source"><summary>Source</summary><pre><code>${escapeHtml(
+      cell.source
+    )}</code></pre></details>`;
+
+    // A cell that failed to bundle has nothing to execute; show the bundler's
+    // error where the preview would be, like the app does.
+    const preview = cell.bundleErr
+      ? `<div class="preview"><pre class="preview-error">${escapeHtml(
+          cell.bundleErr
+        )}</pre></div>`
+      : `<div class="preview"><div class="preview-frame"><iframe title="preview ${cellNumber(
+          index
+        )}" sandbox="allow-scripts" data-cell="${escapeHtml(
+          cell.id
+        )}"></iframe></div><div class="preview-console"><span class="preview-console-title">CONSOLE</span><div class="preview-console-body"></div></div></div>`;
+
+    if (!cell.bundleErr) {
+      bundles[cell.id] = cell.bundledCode;
+    }
+    return `<section class="cell">${header}${source}${preview}</section>`;
+  });
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>My Scrapbook export</title>
+<style>${STYLES}</style>
+</head>
+<body>
+<div class="page">
+<header class="export-header">
+  <span class="brand-mark"></span>
+  <span class="brand-name">MY SCRAPBOOK</span>
+  <span class="export-meta">Exported ${escapeHtml(
+    exportedAt.toLocaleString()
+  )}</span>
+</header>
+<noscript>Code cell previews need JavaScript to run; enable it to see them.</noscript>
+${sections.join('\n')}
+<footer class="export-footer">Made with <a href="https://www.npmjs.com/package/my-scrapbook">My Scrapbook</a> — code cells run live in sandboxed frames, entirely inside this file.</footer>
+</div>
+<script>${runtimeScript(
+    embedJson(PREVIEW_SHELL_HTML),
+    embedJson(bundles)
+  )}</script>
+</body>
+</html>
+`;
+};

--- a/jbook/packages/local-client/src/export/export-notebook.test.ts
+++ b/jbook/packages/local-client/src/export/export-notebook.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { exportNotebookHtml } from './export-notebook';
+import { bundleWithCache } from '../bundler/bundle-with-cache';
+import { Cell } from '../state';
+
+vi.mock('../bundler/bundle-with-cache', () => ({
+  bundleWithCache: vi.fn(async (cellId: string, input: string) => ({
+    code: `/* bundled:${cellId} */`,
+    err: input.includes('broken') ? 'Bundle failed' : '',
+    cached: false,
+  })),
+}));
+
+vi.mock('./render-markdown', () => ({
+  renderMarkdownToHtml: (source: string) => `<p>md:${source}</p>`,
+}));
+
+const cells: Cell[] = [
+  { id: 't1', type: 'text', content: '# Hello' },
+  { id: 'c1', type: 'code', content: 'const a = 1;' },
+  { id: 'c2', type: 'code', content: 'show(a)' },
+];
+
+describe('exportNotebookHtml', () => {
+  let downloaded: { name: string; html: string } | null;
+
+  beforeEach(() => {
+    downloaded = null;
+    // jsdom implements neither object URLs nor navigation; capture the blob
+    // at the point it would become a download.
+    URL.createObjectURL = vi.fn(() => 'blob:fake');
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+      async function (this: HTMLAnchorElement) {
+        const blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+          .calls[0][0] as Blob;
+        downloaded = { name: this.download, html: await blob.text() };
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('bundles each code cell with its cumulative code and downloads the page', async () => {
+    await exportNotebookHtml(cells, 'notebook.html');
+    // click() capture is async (blob.text()); let it settle.
+    await vi.waitFor(() => expect(downloaded).not.toBeNull());
+
+    expect(downloaded!.name).toBe('notebook.html');
+    expect(downloaded!.html).toContain('<p>md:# Hello</p>');
+    expect(downloaded!.html).toContain('/* bundled:c1 */');
+    expect(downloaded!.html).toContain('/* bundled:c2 */');
+
+    const bundleMock = vi.mocked(bundleWithCache);
+    expect(bundleMock).toHaveBeenCalledTimes(2);
+    // The second cell's input accumulates the first cell's code, with the
+    // real show() only in its own segment — same rule the app bundles with.
+    const [, c2Input] = bundleMock.mock.calls[1];
+    expect(c2Input).toContain('const a = 1;');
+    expect(c2Input).toContain('show(a)');
+    expect(bundleMock.mock.calls[1][0]).toBe('c2');
+  });
+
+  it('exports a failed bundle as an error section', async () => {
+    await exportNotebookHtml(
+      [{ id: 'c1', type: 'code', content: 'broken(' }],
+      'notebook.html'
+    );
+    await vi.waitFor(() => expect(downloaded).not.toBeNull());
+
+    expect(downloaded!.html).toContain('Bundle failed');
+    expect(downloaded!.html).not.toContain('<iframe');
+  });
+});

--- a/jbook/packages/local-client/src/export/export-notebook.ts
+++ b/jbook/packages/local-client/src/export/export-notebook.ts
@@ -1,0 +1,45 @@
+import { Cell } from '../state';
+import { cumulativeCodeFor } from '../hooks/use-cumulative-code';
+import { bundleWithCache } from '../bundler/bundle-with-cache';
+import { renderMarkdownToHtml } from './render-markdown';
+import { buildExportHtml, ExportCell } from './export-html';
+
+const downloadHtml = (html: string, filename: string): void => {
+  const url = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};
+
+// Assembles a self-contained HTML file from the notebook and hands it to the
+// browser as a download. Code cells are bundled exactly as the app bundles
+// them (same cumulative input, same cache), so an unchanged notebook exports
+// without re-running esbuild.
+export const exportNotebookHtml = async (
+  orderedCells: Cell[],
+  filename: string
+): Promise<void> => {
+  const items: ExportCell[] = [];
+
+  for (const cell of orderedCells) {
+    if (cell.type === 'text') {
+      items.push({ type: 'text', html: renderMarkdownToHtml(cell.content) });
+    } else {
+      const result = await bundleWithCache(
+        cell.id,
+        cumulativeCodeFor(orderedCells, cell.id)
+      );
+      items.push({
+        type: 'code',
+        id: cell.id,
+        source: cell.content,
+        bundledCode: result.code,
+        bundleErr: result.err,
+      });
+    }
+  }
+
+  downloadHtml(buildExportHtml(items, new Date()), filename);
+};

--- a/jbook/packages/local-client/src/export/render-markdown.test.tsx
+++ b/jbook/packages/local-client/src/export/render-markdown.test.tsx
@@ -1,0 +1,26 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import { renderMarkdownToHtml } from './render-markdown';
+
+// The markdown library is exercised in the browser; this tests the capture
+// mechanics (render, read innerHTML, unmount) against a minimal stand-in.
+vi.mock('@uiw/react-md-editor', () => {
+  const MDEditor = () => null;
+  MDEditor.Markdown = ({ source }: { source?: string }) => (
+    <article className="rendered">{source}</article>
+  );
+  return { default: MDEditor };
+});
+
+describe('renderMarkdownToHtml', () => {
+  it('returns the markup the notebook renderer produces', () => {
+    expect(renderMarkdownToHtml('# Hi')).toBe(
+      '<article class="rendered"># Hi</article>'
+    );
+  });
+
+  it('leaves nothing mounted behind', () => {
+    renderMarkdownToHtml('text');
+    expect(document.body.innerHTML).toBe('');
+  });
+});

--- a/jbook/packages/local-client/src/export/render-markdown.tsx
+++ b/jbook/packages/local-client/src/export/render-markdown.tsx
@@ -1,0 +1,19 @@
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import MDEditor from '@uiw/react-md-editor';
+
+// Renders a text cell's markdown with the same component the notebook
+// displays it with, then captures the resulting HTML — so the export matches
+// what the user sees without shipping a second markdown pipeline.
+export const renderMarkdownToHtml = (source: string): string => {
+  const host = document.createElement('div');
+  const root = createRoot(host);
+  // flushSync forces the render to commit before we read innerHTML; React 18
+  // batches renders asynchronously otherwise.
+  flushSync(() => {
+    root.render(<MDEditor.Markdown source={source} />);
+  });
+  const html = host.innerHTML;
+  root.unmount();
+  return html;
+};

--- a/jbook/packages/local-client/src/state/bundles-slice.ts
+++ b/jbook/packages/local-client/src/state/bundles-slice.ts
@@ -1,6 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import bundler from '../bundler';
-import { getCachedBundle, setCachedBundle } from '../bundler/bundle-cache';
+import { bundleWithCache } from '../bundler/bundle-with-cache';
 
 interface BundlesState {
   [key: string]:
@@ -33,17 +32,7 @@ const createBundleThunk = createAsyncThunk(
     err: string;
     durationMs?: number;
     cached: boolean;
-  }> => {
-    const cached = await getCachedBundle(cellId, input);
-    if (cached) {
-      return { ...cached, cached: true };
-    }
-
-    const started = performance.now();
-    const result = await bundler(input);
-    await setCachedBundle(cellId, input, result);
-    return { ...result, durationMs: performance.now() - started, cached: false };
-  }
+  }> => bundleWithCache(cellId, input)
 );
 
 // Keeps the original two-argument call signature, createBundle(cellId, input).


### PR DESCRIPTION
Adds the **Export HTML** button to the notebook header: one click downloads the whole notebook as a single self-contained `notebook.html` you can send to anyone — no My Scrapbook, server, or network needed.

## What the exported file contains
- **Text cells** as rendered markdown, captured from the same `MDEditor.Markdown` component the app displays with (no second markdown pipeline).
- **Code cells** as a collapsible **Source** toggle (HTML-escaped) plus a **live preview**: the cell's bundled code executes in a `sandbox="allow-scripts"` iframe on open, with forwarded console output rendered under the frame — same semantics as in the app.
- Cells that failed to bundle export the bundler's error where their preview would be.
- Zero external requests: bundles (npm modules baked in), styles, and the runtime script are all inline.

## How it reuses the app's machinery
- The preview iframe document moved to `components/preview-shell.ts`; the app's `Preview` and the export embed the **identical** shell (ready-handshake, console forwarding, error rendering).
- The cache-or-bundle step moved out of the bundles slice into `bundler/bundle-with-cache.ts`, shared with the export — an already-bundled notebook exports instantly, and the existing slice tests' mock seams are preserved.
- Escaping: embedded bundle JSON has `<` escaped (`</script>` inside bundled code can't terminate the runtime script; covered by a test), sources are HTML-escaped.

## Verification
- 120 tests green across the workspace, 9 new (page builder, orchestrator with a captured download, markdown capture).
- End-to-end in the running app: exported a three-cell notebook (markdown / console-only / React `show()`), served the downloaded 1.26 MB file from a bare static server on a different port — markdown renders, both previews execute, console panels populate, Source shows the original code, and the only network request is the HTML file itself.

Changelog has the entry under **Unreleased**; READMEs gained a "Share a notebook as a live HTML page" section. Release prep (version bumps, What's-new) can follow as usual once this merges.