### PR TITLE
Prepare the 3.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.9.0 — 2026-08-02
 
 ### Added
 - **Static HTML export.** An **Export HTML** button in the notebook header downloads the notebook as one self-contained `notebook.html`: text cells as rendered markdown, code cells with their source behind a collapsible toggle plus a live preview — each cell's bundled code executes in a sandboxed iframe with the same shell the app uses (shared, not copied), console output included. The file makes zero network requests, so it works offline and can be shared with anyone. Exporting bundles through the same cache as the app, so an already-bundled notebook exports instantly; cells that fail to bundle export their error message where the preview would be.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
 
+## What's new in 3.9
+
+- **Export a notebook as a live HTML page.** The new **Export HTML** button in the header downloads your notebook as a single self-contained file: markdown rendered, code cells runnable — previews execute and console output appears when the file is opened, in any browser, offline, with nothing installed. See "Share a notebook as a live HTML page" above.
+
 ## What's new in 3.8
 
 - **Node 20 or newer is now required** (Node 18 reached end of life). Under the hood the CLI's dependencies moved to current majors — express 5 and commander 14 — so a command with stray extra arguments now fails with a clear error instead of being silently ignored.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.8.0"
+  "version": "3.9.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.7.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -59,6 +59,10 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
 
+## What's new in 3.9
+
+- **Export a notebook as a live HTML page.** The new **Export HTML** button in the header downloads your notebook as a single self-contained file: markdown rendered, code cells runnable — previews execute and console output appears when the file is opened, in any browser, offline, with nothing installed. See "Share a notebook as a live HTML page" above.
+
 ## What's new in 3.8
 
 - **Node 20 or newer is now required** (Node 18 reached end of life). Under the hood the CLI's dependencies moved to current majors — express 5 and commander 14 — so a command with stray extra arguments now fails with a clear error instead of being silently ignored.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.7.0",
+  "version": "3.9.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.9.0 — ships the static HTML export (#51) to npm.

- `my-scrapbook` and `@my-scrapbook/local-client` → **3.9.0**; `local-api` stays 3.8.0, `types` stays 3.0.0; `lerna.json` syncs to 3.9.0.
- Changelog's Unreleased section retitled to **3.9.0 — 2026-08-02**; both READMEs gain a "What's new in 3.9" section.

Verified: 120 tests green across the workspace; the pack-and-install smoke test passes with the installed CLI reporting 3.9.0.

After merge: push the `v3.9.0` tag and CI publishes the two bumped packages with provenance.