### PR TITLE
Add dark mode: header toggle, remembered choice, OS-preference default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Dark mode.** A sun/moon toggle in the header switches the notebook between light and dark. The choice is remembered per browser; before any choice is made, the OS preference applies. An inline script applies the stored theme before first paint, so reloading in dark mode never flashes light. The dark palette re-derives the design system's roles on a dark ground with each tonal ramp mirrored (dark 100 = light 900, and so on), which lets almost all component CSS work unchanged in both themes; code panes keep their fixed dark look either way (they now use dedicated `--color-code-pane` tokens instead of ramp steps), previews stay white so cell output renders on the same ground in both themes, and the markdown editor follows the theme. Exported HTML pages are unaffected and stay light.
+
 ## 3.9.0 — 2026-08-02
 
 ### Added

--- a/jbook/packages/local-client/index.html
+++ b/jbook/packages/local-client/index.html
@@ -12,6 +12,19 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!-- Set the theme before first paint so a dark-theme reload never
+         flashes light. Mirrors initialTheme() in src/theme-context.tsx. -->
+    <script>
+      try {
+        var t = localStorage.getItem('scrapbook.theme');
+        if (t !== 'light' && t !== 'dark') {
+          t = window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+        document.documentElement.dataset.theme = t;
+      } catch (e) {}
+    </script>
     <div id="root"></div>
     <!-- @babel/traverse reads process.env at module evaluation. The
          production build replaces it statically; the Vite dev server does

--- a/jbook/packages/local-client/src/components/code-cell.css
+++ b/jbook/packages/local-client/src/components/code-cell.css
@@ -51,7 +51,9 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: var(--color-neutral-200);
+  /* Overlays the always-white preview; fixed colors so the track reads the
+     same in both themes. */
+  background: #eae7e7;
   overflow: hidden;
   z-index: 2;
 }
@@ -59,7 +61,7 @@
 .bundle-track-fill {
   height: 100%;
   width: 40%;
-  background: var(--color-accent);
+  background: #ec3013;
   animation: bundle-track-slide 1.1s ease-in-out infinite;
 }
 

--- a/jbook/packages/local-client/src/components/code-editor.css
+++ b/jbook/packages/local-client/src/components/code-editor.css
@@ -4,11 +4,13 @@
   height: 100%;
   flex: 1;
   min-width: 0;
-  background: var(--color-neutral-900);
+  /* Fixed code-pane tokens, not ramp steps: the pane stays dark in both
+     themes while the ramps flip. */
+  background: var(--color-code-pane);
 }
 
 .editor-toolbar {
-  border-bottom: 1px solid var(--color-neutral-800);
+  border-bottom: 1px solid var(--color-code-pane-border);
 }
 
 .editor-toolbar .editor-language {
@@ -21,7 +23,9 @@
   font-weight: var(--font-heading-weight);
   font-size: 11px;
   letter-spacing: 0.02em;
-  color: var(--color-accent-400);
+  /* Sits on the always-dark code pane; a ramp step would flip with the
+     theme and lose contrast there. */
+  color: #ff9783;
   background: transparent;
   border: 0;
   padding: 0;

--- a/jbook/packages/local-client/src/components/notebook-header.tsx
+++ b/jbook/packages/local-client/src/components/notebook-header.tsx
@@ -1,5 +1,7 @@
 import './notebook-header.css';
 import { useEffect, useRef, useState } from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../theme-context';
 import { useTypedSelector } from '../hooks/use-typed-selector';
 import { useActions } from '../hooks/use-actions';
 import { selectCells } from '../state';
@@ -20,6 +22,7 @@ const formatTime = (date: Date) =>
 
 const NotebookHeader: React.FC = () => {
   const { createBundle } = useActions();
+  const { theme, toggleTheme } = useTheme();
   // `present` is referentially stable across non-cell actions (bundles,
   // undo bookkeeping), so the save-state effect only fires on real edits.
   const present = useTypedSelector(selectCells);
@@ -91,6 +94,18 @@ const NotebookHeader: React.FC = () => {
       <span className="header-spacer" />
       <OfflineStatus />
       <UndoRedoBar />
+      <button
+        className="btn btn-secondary theme-toggle"
+        onClick={toggleTheme}
+        aria-label={
+          theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'
+        }
+        title={
+          theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'
+        }
+      >
+        {theme === 'light' ? <Moon size={15} /> : <Sun size={15} />}
+      </button>
       <button
         className="btn btn-secondary export-html"
         onClick={onExportHtml}

--- a/jbook/packages/local-client/src/components/preview.css
+++ b/jbook/packages/local-client/src/components/preview.css
@@ -21,7 +21,9 @@
   right: 12px;
   font-family: var(--font-mono);
   font-size: 13px;
-  color: var(--color-accent-700);
+  /* Overlays the always-white preview area, so the color must not flip
+     with the theme (the dark ramp's 700 is a pale tint). */
+  color: #ae1800;
   word-break: break-word;
 }
 

--- a/jbook/packages/local-client/src/components/text-editor.tsx
+++ b/jbook/packages/local-client/src/components/text-editor.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import MDEditor from '@uiw/react-md-editor';
 import { Cell } from '../state';
 import { useActions } from '../hooks/use-actions';
+import { useTheme } from '../theme-context';
 
 interface TextEditorProps {
   cell: Cell;
@@ -12,6 +13,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ cell }) => {
   const ref = useRef<HTMLDivElement | null>(null);
   const [editing, setEditing] = useState(false);
   const { updateCell } = useActions();
+  // MDEditor themes itself off this attribute rather than our CSS variables.
+  const { theme } = useTheme();
 
   useEffect(() => {
     const listener = (event: MouseEvent) => {
@@ -34,7 +37,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ cell }) => {
 
   if (editing) {
     return (
-      <div className="text-editor editing" ref={ref} data-color-mode="light">
+      <div className="text-editor editing" ref={ref} data-color-mode={theme}>
         <MDEditor
           value={cell.content}
           onChange={(v) => updateCell(cell.id, v || '')}
@@ -50,7 +53,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ cell }) => {
     <div
       className="text-editor"
       onClick={() => setEditing(true)}
-      data-color-mode="light"
+      data-color-mode={theme}
     >
       <div className="text-cell-body">
         <MDEditor.Markdown source={cell.content || 'Click to edit'} />

--- a/jbook/packages/local-client/src/index.tsx
+++ b/jbook/packages/local-client/src/index.tsx
@@ -7,14 +7,17 @@ import "./theme.css";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { store } from "./state";
+import { ThemeProvider } from "./theme-context";
 import NotebookHeader from "./components/notebook-header";
 import CellList from "./components/cell-list";
 
 const App = () => {
   return (
     <Provider store={store}>
-      <NotebookHeader />
-      <CellList />
+      <ThemeProvider>
+        <NotebookHeader />
+        <CellList />
+      </ThemeProvider>
     </Provider>
   );
 };

--- a/jbook/packages/local-client/src/theme-context.test.tsx
+++ b/jbook/packages/local-client/src/theme-context.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, useTheme, THEME_STORAGE_KEY } from './theme-context';
+
+const Probe = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} data-testid="probe">
+      {theme}
+    </button>
+  );
+};
+
+const renderProbe = () =>
+  render(
+    <ThemeProvider>
+      <Probe />
+    </ThemeProvider>
+  );
+
+const stubSystemDark = (matches: boolean) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({ matches }))
+  );
+};
+
+describe('theme context', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    delete document.documentElement.dataset.theme;
+  });
+
+  it('defaults to light when nothing is stored and the OS has no dark preference', () => {
+    // jsdom has no matchMedia at all; the fallback must not crash.
+    renderProbe();
+    expect(screen.getByTestId('probe').textContent).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
+  });
+
+  it('follows the OS dark preference when nothing is stored', () => {
+    stubSystemDark(true);
+    renderProbe();
+    expect(screen.getByTestId('probe').textContent).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  it('lets a stored choice beat the OS preference', () => {
+    stubSystemDark(true);
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    renderProbe();
+    expect(screen.getByTestId('probe').textContent).toBe('light');
+  });
+
+  it('toggles, applies the attribute, and persists the choice', async () => {
+    renderProbe();
+    await userEvent.click(screen.getByTestId('probe'));
+
+    expect(screen.getByTestId('probe').textContent).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+
+    await userEvent.click(screen.getByTestId('probe'));
+    expect(screen.getByTestId('probe').textContent).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+  });
+
+  it('ignores junk in storage', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'zebra');
+    renderProbe();
+    expect(screen.getByTestId('probe').textContent).toBe('light');
+  });
+});

--- a/jbook/packages/local-client/src/theme-context.tsx
+++ b/jbook/packages/local-client/src/theme-context.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+export type Theme = 'light' | 'dark';
+
+// Also read by the pre-paint inline script in index.html; keep in sync.
+export const THEME_STORAGE_KEY = 'scrapbook.theme';
+
+// Browser-chrome color per theme, mirrored into <meta name="theme-color">.
+const THEME_COLORS: Record<Theme, string> = {
+  light: '#f3f2f2',
+  dark: '#191817',
+};
+
+const readStoredTheme = (): Theme | null => {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const systemTheme = (): Theme =>
+  window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+
+// An explicit choice wins; otherwise follow the OS preference.
+export const initialTheme = (): Theme => readStoredTheme() ?? systemTheme();
+
+const applyTheme = (theme: Theme) => {
+  // theme.css keys the dark palette off this attribute.
+  document.documentElement.dataset.theme = theme;
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute('content', THEME_COLORS[theme]);
+};
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState<Theme>(initialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => {
+      const next: Theme = current === 'light' ? 'dark' : 'light';
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, next);
+      } catch {
+        // Private-mode storage failures only lose persistence, not the toggle.
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/jbook/packages/local-client/src/theme.css
+++ b/jbook/packages/local-client/src/theme.css
@@ -4,6 +4,8 @@
    app keeps working offline. */
 
 :root {
+  color-scheme: light;
+
   --color-bg: #f3f2f2;
   --color-surface: #eae9e9;
   --color-text: #201e1d;
@@ -49,6 +51,53 @@
   --shadow-sm: 0 1px 2px color-mix(in srgb, #2d2b2b 14%, transparent);
   --shadow-md: 0 3px 10px color-mix(in srgb, #2d2b2b 16%, transparent);
   --shadow-lg: 0 12px 32px color-mix(in srgb, #2d2b2b 22%, transparent);
+
+  /* Code panes are dark in BOTH themes (the redesign's "dark pane inside
+     light chrome"), so they get their own tokens instead of ramp steps —
+     the ramps flip in dark mode and would turn the panes light. */
+  --color-code-pane: #2d2b2b;
+  --color-code-pane-border: #444141;
+}
+
+/* Dark theme: the same roles re-derived on a dark ground, with each tonal
+   ramp mirrored (dark 100 = light 900 …) so component CSS written against
+   "100 ≈ near the page, 900 ≈ near the text" keeps meaning in both themes.
+   The accent midpoint moves to the ramp's 500 (#ff563c): the light theme's
+   #ec3013 loses too much contrast against a dark ground. The toggle in the
+   header sets data-theme; an inline script in index.html sets it before
+   first paint. */
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  --color-bg: #191817;
+  --color-surface: #242221;
+  --color-text: #eae9e9;
+  --color-accent: #ff563c;
+  --color-divider: color-mix(in srgb, #f8f4f4 32%, transparent);
+
+  --color-neutral-100: #2d2b2b;
+  --color-neutral-200: #444141;
+  --color-neutral-300: #605d5d;
+  --color-neutral-400: #7d7979;
+  --color-neutral-500: #9b9797;
+  --color-neutral-600: #bab6b6;
+  --color-neutral-700: #d7d3d3;
+  --color-neutral-800: #eae7e7;
+  --color-neutral-900: #f8f4f4;
+
+  --color-accent-100: #4d170e;
+  --color-accent-200: #7c1405;
+  --color-accent-300: #ae1800;
+  --color-accent-400: #dd2b0f;
+  --color-accent-500: #ff563c;
+  --color-accent-600: #ff9783;
+  --color-accent-700: #ffc4b8;
+  --color-accent-800: #ffe0d9;
+  --color-accent-900: #fff2ef;
+
+  --shadow-sm: 0 1px 2px color-mix(in srgb, #000000 45%, transparent);
+  --shadow-md: 0 3px 10px color-mix(in srgb, #000000 50%, transparent);
+  --shadow-lg: 0 12px 32px color-mix(in srgb, #000000 60%, transparent);
 }
 
 *,


### PR DESCRIPTION
Adds dark mode to the notebook UI — the last small item standing from the roadmap's "future considerations".

## Behavior
- A **sun/moon toggle** in the header switches themes. The choice persists per browser (`scrapbook.theme`); with no stored choice, the OS `prefers-color-scheme` applies.
- An inline script in `index.html` sets `data-theme` **before first paint**, so reloading in dark mode never flashes light. `<meta name="theme-color">` tracks the theme.

## How the palette works
The dark palette re-derives the Modernist design-system roles on a dark ground and **mirrors each tonal ramp** (dark 100 = light 900, …). Component CSS written against "100 ≈ near the page, 900 ≈ near the text" keeps its meaning in both themes, so almost nothing needed touching. The two kinds of surfaces that *don't* flip get fixed colors instead of ramp steps:
- **Code panes** stay dark in both themes (the redesign's "dark pane inside light chrome") — now on dedicated `--color-code-pane` tokens; Monaco's `modernist-dark` is shared by both modes by design.
- **Previews stay white** — cell output renders on the same ground in both themes (and matches the exported HTML, which stays light). The bundle progress track and preview error text that overlay it are pinned accordingly.

The markdown editor follows the theme via MDEditor's `data-color-mode`.

## Verification
- 106 local-client tests green (5 new: theme context defaults, OS preference, stored-choice precedence, toggle + persistence, junk-in-storage).
- Playwright against the built app: light theme unchanged; dark theme verified across header, guide strip, text cells, code cells (dark editors, white previews, dark console panels showing output), and the open markdown editor; after reload, `data-theme` is already `dark` before the app mounts.

Changelog entry added under **Unreleased**; README "What's new" comes with release prep as usual.