### PR TITLE
Prepare the 3.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.10.0 — 2026-08-02
 
 ### Added
 - **Dark mode.** A sun/moon toggle in the header switches the notebook between light and dark. The choice is remembered per browser; before any choice is made, the OS preference applies. An inline script applies the stored theme before first paint, so reloading in dark mode never flashes light. The dark palette re-derives the design system's roles on a dark ground with each tonal ramp mirrored (dark 100 = light 900, and so on), which lets almost all component CSS work unchanged in both themes; code panes keep their fixed dark look either way (they now use dedicated `--color-code-pane` tokens instead of ramp steps), previews stay white so cell output renders on the same ground in both themes, and the markdown editor follows the theme. Exported HTML pages are unaffected and stay light.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
 
+## What's new in 3.10
+
+- **Dark mode.** Click the moon in the header to switch the notebook to a dark theme — your choice is remembered, and until you choose, the app follows your system preference. Code panes were always dark; now the rest of the notebook can match. Previews keep their white background so your cells render the same in both themes.
+
 ## What's new in 3.9
 
 - **Export a notebook as a live HTML page.** The new **Export HTML** button in the header downloads your notebook as a single self-contained file: markdown rendered, code cells runnable — previews execute and console output appears when the file is opened, in any browser, offline, with nothing installed. See "Share a notebook as a live HTML page" above.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.9.0"
+  "version": "3.10.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -59,6 +59,10 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
 
+## What's new in 3.10
+
+- **Dark mode.** Click the moon in the header to switch the notebook to a dark theme — your choice is remembered, and until you choose, the app follows your system preference. Code panes were always dark; now the rest of the notebook can match. Previews keep their white background so your cells render the same in both themes.
+
 ## What's new in 3.9
 
 - **Export a notebook as a live HTML page.** The new **Export HTML** button in the header downloads your notebook as a single self-contained file: markdown rendered, code cells runnable — previews execute and console output appears when the file is opened, in any browser, offline, with nothing installed. See "Share a notebook as a live HTML page" above.

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.10.0 — ships dark mode (#53) to npm.

- `my-scrapbook` and `@my-scrapbook/local-client` → **3.10.0**; `local-api` stays 3.8.0, `types` stays 3.0.0; `lerna.json` syncs.
- Changelog's Unreleased section retitled to **3.10.0 — 2026-08-02**; both READMEs gain a "What's new in 3.10" section.

Verified: 125 tests green across the workspace; the pack-and-install smoke test passes with the installed CLI reporting 3.10.0.

After merge: push the `v3.10.0` tag and CI publishes the two bumped packages with provenance.