### PR TITLE
Make exported HTML pages theme-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Exported HTML pages are now theme-aware.** An exported notebook follows its viewer's OS color preference and has its own Dark/Light toggle in the header, with the choice remembered per browser — the same stored-choice-beats-OS rule as the app, applied before first paint so a dark reload never flashes light. With JavaScript disabled the page still themes via `prefers-color-scheme` (and the toggle stays hidden). As in the app, previews keep their white ground and source blocks stay dark in both themes.
+
 ## 3.10.0 — 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
+- The page matches its reader's light or dark preference and has its own theme toggle — independent of the theme you were using when you exported.
 
 ## What's new in 3.10
 

--- a/jbook/packages/cli/README.md
+++ b/jbook/packages/cli/README.md
@@ -58,6 +58,7 @@ npx my-scrapbook export mynotes.js -o docs/mynotes.md
 - Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
+- The page matches its reader's light or dark preference and has its own theme toggle — independent of the theme you were using when you exported.
 
 ## What's new in 3.10
 

--- a/jbook/packages/local-client/src/export/export-html.test.ts
+++ b/jbook/packages/local-client/src/export/export-html.test.ts
@@ -45,9 +45,27 @@ describe('buildExportHtml', () => {
       exportedAt
     );
 
-    // The only literal closing tag is the runtime script's own.
-    expect(html.match(/<\/script>/g)).toHaveLength(1);
+    // The only literal closing tags are the page's own two scripts
+    // (pre-paint theme script in <head>, runtime script in <body>).
+    expect(html.match(/<\/script>/g)).toHaveLength(2);
     expect(html).toContain('\\u003c/script>');
+  });
+
+  it('themes the page: dark palette, OS-preference fallback, and a toggle', () => {
+    const html = buildExportHtml([codeCell()], exportedAt);
+
+    expect(html).toContain(":root[data-theme='dark']");
+    // Without JavaScript the pre-paint script never sets data-theme; the
+    // media query must cover that case.
+    expect(html).toContain('@media (prefers-color-scheme: dark)');
+    expect(html).toContain(':root:not([data-theme])');
+    // Pre-paint script and toggle share the storage key.
+    expect(html.match(/scrapbook\.export\.theme/g)!.length).toBeGreaterThanOrEqual(
+      2
+    );
+    // The toggle ships hidden so it stays out of the noscript rendering.
+    expect(html).toContain('id="theme-toggle"');
+    expect(html).toMatch(/<button[^>]*theme-toggle[^>]*hidden/);
   });
 
   it('sandboxes every preview iframe', () => {

--- a/jbook/packages/local-client/src/export/export-html.ts
+++ b/jbook/packages/local-client/src/export/export-html.ts
@@ -27,16 +27,57 @@ const escapeHtml = (text: string): string =>
 const embedJson = (value: unknown): string =>
   JSON.stringify(value).replace(/</g, '\\u003c');
 
+// The exported page remembers the viewer's theme choice under its own key
+// (the viewer is usually not the exporter, so the app's key is not reused).
+const EXPORT_THEME_STORAGE_KEY = 'scrapbook.export.theme';
+
+// Dark values mirror the app's dark mode. Kept in one string because they
+// are emitted twice: once for an explicit data-theme="dark" (set by the
+// pre-paint script and the toggle) and once as a prefers-color-scheme
+// fallback for the no-JavaScript case, where data-theme is never set.
+const DARK_VARS = `
+    color-scheme: dark;
+    --bg: #191817;
+    --surface: #242221;
+    --text: #eae9e9;
+    --muted: #a49f97;
+    --border: #403c39;
+    --border-soft: #35322f;
+    --accent: #ff563c;
+    --inline-code-bg: #35322f;
+    --error-text: #ff9783;
+    --error-bg: #33201c;
+    --warn-text: #e3b341;
+`;
+
 const STYLES = `
-  :root { color-scheme: light; }
+  :root {
+    color-scheme: light;
+    --bg: #f4f2ee;
+    --surface: #ffffff;
+    --text: #191919;
+    --muted: #6f6a62;
+    --border: #d9d5cd;
+    --border-soft: #ece9e3;
+    --accent: #e33d2e;
+    --inline-code-bg: #f4f2ee;
+    --error-text: #b3261e;
+    --error-bg: #fdf1f0;
+    --warn-text: #8a6d00;
+  }
+  :root[data-theme='dark'] {${DARK_VARS}}
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {${DARK_VARS}}
+  }
   * { box-sizing: border-box; }
   body {
     margin: 0;
-    background: #f4f2ee;
-    color: #191919;
+    background: var(--bg);
+    color: var(--text);
     font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
     line-height: 1.55;
   }
+  a { color: var(--accent); }
   .page { max-width: 860px; margin: 0 auto; padding: 32px 24px 64px; }
   .export-header {
     display: flex;
@@ -44,12 +85,24 @@ const STYLES = `
     gap: 12px;
     padding-bottom: 18px;
     margin-bottom: 28px;
-    border-bottom: 2px solid #d9d5cd;
+    border-bottom: 2px solid var(--border);
   }
-  .export-header .brand-mark { width: 14px; height: 14px; background: #e33d2e; }
+  .export-header .brand-mark { width: 14px; height: 14px; background: var(--accent); }
   .export-header .brand-name { font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
-  .export-header .export-meta { margin-left: auto; font-size: 12px; color: #6f6a62; }
-  .cell { background: #ffffff; border: 1px solid #d9d5cd; margin-bottom: 26px; }
+  .export-header .export-meta { margin-left: auto; font-size: 12px; color: var(--muted); }
+  .theme-toggle {
+    border: 1px solid var(--border);
+    background: none;
+    color: var(--muted);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 4px 10px;
+    cursor: pointer;
+  }
+  .cell { background: var(--surface); border: 1px solid var(--border); margin-bottom: 26px; }
   .cell-header {
     display: flex;
     gap: 10px;
@@ -57,26 +110,26 @@ const STYLES = `
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.08em;
-    color: #6f6a62;
-    border-bottom: 1px solid #ece9e3;
+    color: var(--muted);
+    border-bottom: 1px solid var(--border-soft);
   }
   .text-cell-body { padding: 6px 18px 14px; }
   .text-cell-body :first-child { margin-top: 8px; }
   .text-cell-body pre, .text-cell-body code {
-    background: #f4f2ee;
+    background: var(--inline-code-bg);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.92em;
   }
   .text-cell-body pre { padding: 10px 12px; overflow-x: auto; }
-  .text-cell-body blockquote { border-left: 3px solid #d9d5cd; margin-left: 0; padding-left: 14px; color: #52504b; }
+  .text-cell-body blockquote { border-left: 3px solid var(--border); margin-left: 0; padding-left: 14px; color: var(--muted); }
   .text-cell-body table { border-collapse: collapse; }
-  .text-cell-body th, .text-cell-body td { border: 1px solid #d9d5cd; padding: 4px 10px; }
+  .text-cell-body th, .text-cell-body td { border: 1px solid var(--border); padding: 4px 10px; }
   .text-cell-body img { max-width: 100%; }
   .code-source summary {
     cursor: pointer;
     padding: 8px 14px;
     font-size: 12px;
-    color: #6f6a62;
+    color: var(--muted);
     user-select: none;
   }
   .code-source pre {
@@ -89,26 +142,26 @@ const STYLES = `
     font-size: 13px;
     line-height: 1.5;
   }
-  .preview { border-top: 1px solid #ece9e3; }
+  .preview { border-top: 1px solid var(--border-soft); }
   .preview-frame { resize: vertical; overflow: hidden; height: 240px; min-height: 80px; }
   .preview-frame iframe { display: block; border: 0; width: 100%; height: 100%; background: #fff; }
   .preview-error {
     margin: 0;
     padding: 12px 16px;
-    color: #b3261e;
-    background: #fdf1f0;
+    color: var(--error-text);
+    background: var(--error-bg);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 13px;
     white-space: pre-wrap;
   }
-  .preview-console { border-top: 1px solid #ece9e3; display: none; }
+  .preview-console { border-top: 1px solid var(--border-soft); display: none; }
   .preview-console-title {
     display: block;
     padding: 6px 14px 0;
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.08em;
-    color: #6f6a62;
+    color: var(--muted);
   }
   .preview-console-body {
     max-height: 180px;
@@ -118,10 +171,10 @@ const STYLES = `
     font-size: 12px;
   }
   .preview-console-entry { padding: 1px 0; white-space: pre-wrap; }
-  .preview-console-warn { color: #8a6d00; }
-  .preview-console-error { color: #b3261e; }
-  .export-footer { font-size: 12px; color: #6f6a62; }
-  noscript { display: block; padding: 12px 16px; color: #b3261e; }
+  .preview-console-warn { color: var(--warn-text); }
+  .preview-console-error { color: var(--error-text); }
+  .export-footer { font-size: 12px; color: var(--muted); }
+  noscript { display: block; padding: 12px 16px; color: var(--error-text); }
 `;
 
 // The script that brings the exported page's previews to life. It mirrors
@@ -172,6 +225,32 @@ const runtimeScript = (
       body.scrollTop = body.scrollHeight;
     }
   });
+
+  // Theme toggle. The pre-paint script in <head> has already set data-theme
+  // from the viewer's stored choice or OS preference; the button (hidden
+  // without JavaScript) flips it and remembers the choice.
+  var toggleBtn = document.getElementById('theme-toggle');
+  var setToggleUi = function () {
+    var dark = document.documentElement.getAttribute('data-theme') === 'dark';
+    toggleBtn.textContent = dark ? 'Light' : 'Dark';
+    toggleBtn.setAttribute(
+      'aria-label',
+      dark ? 'Switch to light theme' : 'Switch to dark theme'
+    );
+  };
+  toggleBtn.hidden = false;
+  setToggleUi();
+  toggleBtn.addEventListener('click', function () {
+    var next =
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'light'
+        : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try {
+      localStorage.setItem('${EXPORT_THEME_STORAGE_KEY}', next);
+    } catch (e) {}
+    setToggleUi();
+  });
 `;
 
 const cellNumber = (index: number): string =>
@@ -220,6 +299,15 @@ export const buildExportHtml = (
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>My Scrapbook export</title>
 <style>${STYLES}</style>
+<script>
+try {
+  var t = localStorage.getItem('${EXPORT_THEME_STORAGE_KEY}');
+  if (t !== 'light' && t !== 'dark') {
+    t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', t);
+} catch (e) {}
+</script>
 </head>
 <body>
 <div class="page">
@@ -229,6 +317,7 @@ export const buildExportHtml = (
   <span class="export-meta">Exported ${escapeHtml(
     exportedAt.toLocaleString()
   )}</span>
+  <button class="theme-toggle" id="theme-toggle" type="button" hidden>Dark</button>
 </header>
 <noscript>Code cell previews need JavaScript to run; enable it to see them.</noscript>
 ${sections.join('\n')}


### PR DESCRIPTION
Follow-up to dark mode (#53): exported notebooks now theme themselves for their **viewer**.

## Behavior
- The exported page follows the viewer's OS color preference by default and has its own **Dark/Light toggle** in the header; the choice persists per browser under `scrapbook.export.theme` (its own key — the viewer usually isn't the exporter).
- A pre-paint script in `<head>` applies the theme before first paint (no light flash on dark reloads) — same pattern as the app.
- **No-JS fallback:** a `prefers-color-scheme` media query themes the page when scripts are off (`:root:not([data-theme])` so it never fights an explicit choice), and the toggle ships `hidden`, revealed only by the runtime script.
- As in the app: previews keep their white ground (cell output renders identically in both themes) and source blocks stay dark.

## Implementation
The export stylesheet moved onto CSS custom properties; dark values live in one `DARK_VARS` string emitted twice (explicit `data-theme='dark'` + the media-query fallback), so the palettes can't drift.

## Verification
- 107 local-client tests green — the `</script>`-count injection assertion now expects the page's two legitimate scripts, and new assertions cover the dark block, the fallback selector, the shared storage key, and the hidden toggle.
- Playwright against a real export (downloaded from the running app, opened via `file://`): light-OS default → toggle to dark → persists across reload; fresh dark-OS profile defaults dark with the toggle reading "Light"; JS-disabled dark-OS page themes dark with the toggle hidden. Dark screenshots show live previews and console output rendering correctly.