### PR TITLE
Prepare the 3.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.10.1 — 2026-08-02
 
 ### Changed
 - **Exported HTML pages are now theme-aware.** An exported notebook follows its viewer's OS color preference and has its own Dark/Light toggle in the header, with the choice remembered per browser — the same stored-choice-beats-OS rule as the app, applied before first paint so a dark reload never flashes light. With JavaScript disabled the page still themes via `prefers-color-scheme` (and the toggle stays hidden). As in the app, previews keep their white ground and source blocks stay dark in both themes.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.10.0"
+  "version": "3.10.1"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.10.1 — ships the theme-aware HTML export (#55) to npm as a patch.

- `my-scrapbook` and `@my-scrapbook/local-client` → **3.10.1**; `local-api` stays 3.8.0, `types` stays 3.0.0; `lerna.json` syncs.
- Changelog's Unreleased section retitled to **3.10.1 — 2026-08-02**. No What's-new section (patch); the READMEs' export docs already describe the behavior.

Verified: 126 tests green; pack-and-install smoke test passes with the installed CLI reporting 3.10.1.

After merge: push `v3.10.1` and CI publishes with provenance.