### PR TITLE
Add CLI arg-parsing tests; build local-api before tests in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,18 +53,20 @@ jobs:
         run: npm ci
         working-directory: jbook
 
-      - name: Test
-        run: npm test
-        working-directory: jbook
-
-      # The cli bundle resolves @my-scrapbook/local-api through the workspace
-      # symlink to its dist output. When local-api itself is skipped (already
-      # published), its prepublishOnly never runs — so build it explicitly or
-      # the cli's esbuild step fails with "could not resolve". (types builds
-      # via its prepare script during npm ci.)
+      # Built BEFORE the tests: the cli's serve tests import (a mock of)
+      # @my-scrapbook/local-api, and vitest still resolves the specifier to
+      # the package's dist entry point, which must exist. The cli bundle
+      # below needs it for the same reason. When local-api itself is skipped
+      # at publish time (already on the registry), its prepublishOnly never
+      # runs — so build it explicitly here. (types builds via its prepare
+      # script during npm ci.)
       - name: Build workspace dependencies
         run: npx tsc
         working-directory: jbook/packages/local-api
+
+      - name: Test
+        run: npm test
+        working-directory: jbook
 
       # Dependency order: types -> local-api -> local-client -> cli. Each
       # package's prepublishOnly script builds it. Versions already on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **CLI command tests.** The `serve` and `export` commands' argument parsing is now unit-tested (13 tests): default and named notebooks, nested paths, port and `--no-open`/`-o` flags, the friendly port-in-use and missing-notebook errors, the refuse-to-overwrite guard, and commander's excess-argument rejection. This closes the last deferred item from the original test-coverage roadmap. The publish workflow now builds local-api before running tests (the new tests resolve its package entry), mirroring CI's existing order.
+
 ## 3.10.1 — 2026-08-02
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -183,7 +183,7 @@
 - [x] Test thunks (saveCells, fetchCells) with mocked axios (PR #14)
 - [x] Test bundler plugins (fetch-plugin, unpkg-path-plugin) at 100% coverage (PR #14)
 - [x] Test API routes (/cells GET, POST) with supertest, incl. validation and corrupted-file cases (PR #14)
-- [ ] Test CLI command parsing (deferred; the serve command is a thin commander wrapper)
+- [x] Test CLI command parsing (serve/export: defaults, flags, nested paths, error paths, excess-argument rejection)
 
 #### Phase 3: Integration Tests
 - [ ] Test Express server setup (partially covered via the router tests; the proxy path was verified manually in PR #9)

--- a/jbook/packages/cli/src/commands/export.test.ts
+++ b/jbook/packages/cli/src/commands/export.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { exportCommand } from './export';
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(async () => {}),
+  },
+}));
+
+const NOTEBOOK_JSON = JSON.stringify([
+  { id: 't1', type: 'text', content: '# Hello' },
+  { id: 'c1', type: 'code', content: 'show(1)' },
+]);
+
+const program = exportCommand.parent!;
+// exitOverride is per-command and does not propagate to subcommands that
+// already exist, so it goes on both.
+program.exitOverride();
+exportCommand.exitOverride();
+const run = (args: string[]) => program.parseAsync(args, { from: 'user' });
+
+describe('export command parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFile).mockResolvedValue(NOTEBOOK_JSON);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to notebook.js and writes notebook.md beside it', async () => {
+    await run(['export']);
+
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.resolve(process.cwd(), 'notebook.js'),
+      'utf-8'
+    );
+    const [outPath, markdown] = vi.mocked(fs.writeFile).mock.calls[0];
+    expect(outPath).toBe(path.resolve(process.cwd(), 'notebook.md'));
+    expect(markdown).toContain('# Hello');
+    expect(markdown).toContain('show(1)');
+  });
+
+  it('derives the default output name from a named notebook', async () => {
+    await run(['export', 'docs/notes.js']);
+
+    expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(
+      path.resolve(process.cwd(), 'docs/notes.md')
+    );
+  });
+
+  it('-o picks the output path', async () => {
+    await run(['export', 'notes.js', '-o', 'out/readme.md']);
+
+    expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(
+      path.resolve(process.cwd(), 'out/readme.md')
+    );
+  });
+
+  it('refuses to overwrite the notebook itself, before reading anything', async () => {
+    await expect(
+      run(['export', 'notebook.js', '-o', 'notebook.js'])
+    ).rejects.toThrow('exit:1');
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('would overwrite the notebook itself')
+    );
+    expect(fs.readFile).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('points at serve when the notebook does not exist', async () => {
+    vi.mocked(fs.readFile).mockRejectedValueOnce(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    await expect(run(['export', 'missing.js'])).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('No notebook found at missing.js')
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('my-scrapbook serve missing.js')
+    );
+  });
+
+  it('reports an unparseable notebook and exits 1', async () => {
+    vi.mocked(fs.readFile).mockResolvedValueOnce('not json at all');
+
+    await expect(run(['export'])).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Could not export notebook.js')
+    );
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects excess arguments', async () => {
+    await expect(run(['export', 'a.js', 'b.js'])).rejects.toMatchObject({
+      code: 'commander.excessArguments',
+    });
+    expect(fs.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/jbook/packages/cli/src/commands/serve.test.ts
+++ b/jbook/packages/cli/src/commands/serve.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import { serveCommand } from './serve';
+import { serve } from '@my-scrapbook/local-api';
+import { openBrowser } from '../open-browser';
+
+vi.mock('@my-scrapbook/local-api', () => ({
+  serve: vi.fn(async () => {}),
+}));
+vi.mock('../open-browser', () => ({
+  openBrowser: vi.fn(),
+}));
+
+// serveCommand is a subcommand; parsing goes through its (anonymous) parent.
+// exitOverride makes commander's own errors (unknown option, excess
+// arguments) throw instead of exiting the process.
+const program = serveCommand.parent!;
+// exitOverride is per-command and does not propagate to subcommands that
+// already exist, so it goes on both.
+program.exitOverride();
+serveCommand.exitOverride();
+const run = (args: string[]) => program.parseAsync(args, { from: 'user' });
+
+describe('serve command parsing', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The action calls process.exit(1) on failure; turn that into a throw so
+    // the test can observe it (and nothing actually exits).
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to notebook.js on port 4005 and opens the browser', async () => {
+    await run(['serve']);
+
+    expect(serve).toHaveBeenCalledWith(
+      4005,
+      'notebook.js',
+      process.cwd(),
+      true
+    );
+    expect(openBrowser).toHaveBeenCalledWith('http://localhost:4005');
+  });
+
+  it('parses a nested filename and a custom port', async () => {
+    await run(['serve', 'docs/notes.js', '-p', '4100']);
+
+    expect(serve).toHaveBeenCalledWith(
+      4100,
+      'notes.js',
+      path.join(process.cwd(), 'docs'),
+      true
+    );
+    expect(openBrowser).toHaveBeenCalledWith('http://localhost:4100');
+  });
+
+  it('--no-open starts the server without launching a browser', async () => {
+    await run(['serve', '--no-open']);
+
+    expect(serve).toHaveBeenCalled();
+    expect(openBrowser).not.toHaveBeenCalled();
+  });
+
+  it('explains an in-use port and exits 1', async () => {
+    const err = Object.assign(new Error('listen EADDRINUSE'), {
+      code: 'EADDRINUSE',
+    });
+    vi.mocked(serve).mockRejectedValueOnce(err);
+
+    await expect(run(['serve', 'notes.js', '-p', '4005'])).rejects.toThrow(
+      'exit:1'
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Port 4005 is already in use')
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('my-scrapbook serve notes.js -p <port>')
+    );
+    expect(openBrowser).not.toHaveBeenCalled();
+  });
+
+  it('reports other startup failures with file and port context', async () => {
+    vi.mocked(serve).mockRejectedValueOnce(new Error('EACCES boom'));
+
+    await expect(run(['serve'])).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to open notebook.js on port 4005')
+    );
+  });
+
+  it('rejects excess arguments instead of silently ignoring them', async () => {
+    await expect(run(['serve', 'a.js', 'b.js'])).rejects.toMatchObject({
+      code: 'commander.excessArguments',
+    });
+    expect(serve).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes the last open roadmap item: the `serve` and `export` commands were the only untested CLI surface.

## Tests (13 new, driven through commander's real parsing)
- **serve**: defaults (`notebook.js`, port 4005, browser auto-open), nested filename + custom port (dirname/basename split as passed to local-api), `--no-open`, the friendly `EADDRINUSE` hint including the retry command, generic startup-failure context, and excess-argument rejection (the commander-14 behavior we shipped in 3.8.0).
- **export**: default + derived output names (`docs/notes.js` → `docs/notes.md`), `-o`, the refuse-to-overwrite guard firing before any file I/O, the ENOENT message pointing at `serve`, unparseable-notebook failure, and excess-argument rejection.
- Technique notes: `parseAsync(args, { from: 'user' })` on the command's parent; `exitOverride()` on **both** parent and subcommand (it's per-command and doesn't propagate to pre-existing subcommands); `process.exit` spied to throw so action-level failures are assertable.

## publish.yml ordering fix
The new serve tests import (a mock of) `@my-scrapbook/local-api`, and vitest still resolves the specifier to the package's dist entry — which doesn't exist at publish time before the build step. **Verified empirically**: with `local-api/dist` removed, the cli suite fails collection. The workflow now builds local-api before `npm test` (matching ci.yml's existing order); the duplicate post-test build step is removed.

## Verification
139 tests green across the workspace (22 cli + 10 local-api + 107 local-client). TODO item 10's last checkbox closed; changelog entry under Unreleased.