### PR TITLE
Prepare the 3.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 3.10.2 — 2026-08-02
+
+No functional changes.
 
 ### Added
 - **CLI command tests.** The `serve` and `export` commands' argument parsing is now unit-tested (13 tests): default and named notebooks, nested paths, port and `--no-open`/`-o` flags, the friendly port-in-use and missing-notebook errors, the refuse-to-overwrite guard, and commander's excess-argument rejection. This closes the last deferred item from the original test-coverage roadmap. The publish workflow now builds local-api before running tests (the new tests resolve its package entry), mirroring CI's existing order.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.10.1"
+  "version": "3.10.2"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",


### PR DESCRIPTION
Release prep for 3.10.2 — a meta release: CLI command tests (#57) plus the publish-workflow ordering fix, no functional changes.

- `my-scrapbook` → **3.10.2** (local-client stays 3.10.1, local-api 3.8.0, types 3.0.0); `lerna.json` syncs.
- Changelog's Unreleased section retitled to **3.10.2 — 2026-08-02**.

Verified: 139 tests green; pack-and-install smoke test passes with the installed CLI reporting 3.10.2.

After merge: push `v3.10.2` — this will be the first run of the reordered publish workflow (local-api built before tests).