### PR TITLE
Markdown import, esbuild.wasm fallback, full CI support matrix (3.11 scope)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,32 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The full engines range (>=20) on Linux, plus one current-LTS job on
+        # each other OS — the CLI writes files, resolves paths, and spawns a
+        # server, all of which are platform-sensitive.
+        os: [ubuntu-latest]
+        node: [20, 22, 24]
+        include:
+          - os: windows-latest
+            node: 22
+          - os: macos-latest
+            node: 22
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: jbook
+        # bash everywhere, including Windows: the build steps and the smoke
+        # script are written for it.
+        shell: bash
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: jbook/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
           - os: macos-latest
             node: 22
     runs-on: ${{ matrix.os }}
+    env:
+      # The local-client vite build (it bundles a self-hosted Monaco) needs
+      # more heap than Node's default on the 7 GB macOS runners.
+      NODE_OPTIONS: --max-old-space-size=4096
     defaults:
       run:
         working-directory: jbook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,16 @@ jobs:
         working-directory: jbook/packages/cli
 
       - name: Test
+        if: matrix.node != 20
         run: npm test
+
+      # jsdom 30's bundled undici needs worker_threads.markAsUncloneable
+      # (added in Node 22.10), so local-client's browser-env suites can't run
+      # on Node 20. The cli and local-api suites plus the smoke test below
+      # still exercise everything the shipped package runs on Node 20.
+      - name: Test (Node 20 — cli and local-api only)
+        if: matrix.node == 20
+        run: npm run test --workspace=my-scrapbook --workspace=@my-scrapbook/local-api
 
       # Packs the packages and installs the cli from the tarballs in a scratch
       # project, then runs it — catches packaging bugs (missing dist files,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Markdown import.** `my-scrapbook import notes.md` creates a notebook from a markdown file — the inverse of `export`. Fenced `js`/`jsx`/`ts`/`tsx` blocks (case-insensitive, any CommonMark fence length, unclosed fences run to end of file) become code cells; everything between them becomes text cells, with fenced blocks in other languages kept as markdown inside them. Output defaults to the markdown name with `.js`, `-o` picks another path, and an existing notebook is never overwritten without `-f`. A notebook survives `export` → `import` unchanged (verified by a round-trip test).
+- **esbuild.wasm fallback.** If the locally bundled WebAssembly binary fails to load (e.g. a corrupted install), the bundler now retries from unpkg, pinned to the installed esbuild-wasm version so the binary always matches the JS API. A failed initialization still isn't cached — the next bundle retries both sources.
+
+### Changed
+- **CI now covers the whole support matrix**: Node 20, 22, and 24 on Linux, plus Node 22 on Windows and macOS — build, unit tests, and the pack-and-install smoke test all run on every job. The smoke script's one non-portable line (a `node -p require()` with an interpolated absolute path) now passes the path as an argument so Git Bash on Windows converts it.
+- README gains a "Works offline" section documenting what already worked — self-hosted app shell and editor, IndexedDB module cache, offline indicator — plus the new wasm fallback; TODO.md checkboxes that had actually shipped (UUID test, invalid-input API tests, `useCumulativeCode` memoization) are marked done.
+
 ## 3.10.2 — 2026-08-02
 
 No functional changes.

--- a/README.md
+++ b/README.md
@@ -54,12 +54,40 @@ npx my-scrapbook export
 npx my-scrapbook export mynotes.js -o docs/mynotes.md
 ```
 
+## Import a notebook from Markdown
+
+- Going the other way works too — turn any markdown file into a notebook:
+
+```
+npx my-scrapbook import notes.md
+```
+
+- This writes **notes.js** next to **notes.md**: fenced `js` / `jsx` / `ts` / `tsx` blocks become runnable code cells, and everything between them becomes text cells. Fenced blocks in other languages (python, bash, …) stay inside the text cells as ordinary markdown.
+- It won't overwrite an existing notebook unless you pass `-f`, and `-o` picks a different output name:
+
+```
+npx my-scrapbook import notes.md -o scratch.js
+```
+
+- `export` and `import` are inverses, so a notebook survives the round trip unchanged — edit your notebook as markdown in another tool and bring it back, or bootstrap a notebook from a README.
+
 ## Share a notebook as a live HTML page
 
 - Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
 - The file is completely self-contained — open it in any browser, no My Scrapbook, server, or internet connection needed. Text cells keep their formatting, and code cells **actually run**: each one executes its bundled code in a sandboxed frame, renders its preview, and shows its console output, exactly like in the app.
 - Each code cell's source is included too, behind a collapsible **Source** toggle.
 - The page matches its reader's light or dark preference and has its own theme toggle — independent of the theme you were using when you exported.
+
+## Works offline
+
+- Once installed, My Scrapbook doesn't need the internet: the app, the editor, and the bundler all ship with the package and are served from your machine.
+- npm imports are fetched once and cached in your browser (IndexedDB). A package you've used before keeps working offline; only importing a *new* package needs a connection. The header shows an offline indicator, and a **Clear module cache** button refetches fresh versions when you want them.
+- The bundler's WebAssembly binary is bundled locally too, with unpkg (pinned to the matching version) as an automatic fallback if the local copy ever fails to load.
+
+## What's new in 3.11
+
+- **Import from markdown.** `npx my-scrapbook import notes.md` turns a markdown file into a notebook — the inverse of `export`, and a round trip through both leaves a notebook unchanged. See "Import a notebook from Markdown" above.
+- The esbuild WebAssembly binary now falls back to unpkg (version-pinned) if the locally shipped copy fails to load, and CI now tests every supported Node version (20/22/24) on Linux, Windows, and macOS.
 
 ## What's new in 3.10
 

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@
 
 - [x] Install `uuid` package in local-client (PR #10)
 - [x] Replace `Math.random().toString(36).substr(2, 5)` with `uuidv4()` (PR #10)
-- [ ] Add unit test for unique ID generation (deferred to item 10 — no test infrastructure yet)
+- [x] Add unit test for unique ID generation (landed with the cellsReducer suite in PR #14, which covers UUID uniqueness)
 - [x] Migration note: Existing 5-char IDs still work (IDs are opaque keys)
 
 **Files:**
@@ -144,7 +144,7 @@
 - [x] Validate POST /cells request body (PR #13)
 - [x] Return 400 with validation errors (PR #13)
 - [x] Add request body size limits (5mb explicit; express default was 100kb) (PR #13)
-- [ ] Add tests for invalid inputs (deferred to item 10 — no test infrastructure yet; the cases were exercised manually against the running server)
+- [x] Add tests for invalid inputs (landed with the API route tests in PR #14: validation rejections and corrupted-file cases)
 
 **Files:**
 - `jbook/packages/local-api/src/routes/cells.ts:33-42`
@@ -158,9 +158,9 @@
 
 - [x] Ship esbuild.wasm locally — bundled from the installed package via Vite `?url` import (PR #7)
 - [x] Update bundler to use the local WASM file (PR #7)
-- [ ] Fallback to unpkg if local fails
+- [x] Fallback to unpkg if local fails (pinned to the installed version; 3.11)
 - [x] Version always matches the installed esbuild-wasm package (PR #7)
-- [ ] Update README with offline capabilities
+- [x] Update README with offline capabilities ("Works offline" section; 3.11)
 
 **Files:**
 - `jbook/packages/local-client/src/bundler/index.ts:10`
@@ -214,10 +214,9 @@
 **Effort:** 2 days
 **Impact:** Faster re-renders, less bundling
 
-- [ ] Memoize `useCumulativeCode` hook with `useMemo`
-- [ ] Track cell dependencies
-- [ ] Only rebundle cells affected by changes
-- [ ] Add performance monitoring
+- [x] Memoize `useCumulativeCode` hook — done via a per-instance `createSelector` (the join only recomputes when the cells slice changes)
+- [x] ~~Track cell dependencies~~ / ~~Only rebundle cells affected by changes~~ obsolete — unchanged cells already skip rebundling: cumulative code is a string, so an edit to cell N leaves the selector output for cells above it `===`-equal and their debounced rebundle never fires
+- [ ] Add performance monitoring (not planned; no observed need at notebook sizes)
 
 **Files:**
 - `jbook/packages/local-client/src/hooks/use-cumulative-code.ts`

--- a/jbook/packages/cli/src/commands/import.test.ts
+++ b/jbook/packages/cli/src/commands/import.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { importCommand } from './import';
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(async () => {}),
+    access: vi.fn(),
+  },
+}));
+
+const MARKDOWN = '# Hello\n\n```jsx\nshow(1);\n```\n';
+
+const program = importCommand.parent!;
+// exitOverride is per-command and does not propagate to subcommands that
+// already exist, so it goes on both.
+program.exitOverride();
+importCommand.exitOverride();
+const run = (args: string[]) => program.parseAsync(args, { from: 'user' });
+
+describe('import command parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.readFile).mockResolvedValue(MARKDOWN);
+    // Default: the output notebook does not exist yet.
+    vi.mocked(fs.access).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to notebook.md and writes notebook.js beside it', async () => {
+    await run(['import']);
+
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.resolve(process.cwd(), 'notebook.md'),
+      'utf-8'
+    );
+    const [outPath, json] = vi.mocked(fs.writeFile).mock.calls[0];
+    expect(outPath).toBe(path.resolve(process.cwd(), 'notebook.js'));
+    const cells = JSON.parse(json as string);
+    expect(cells).toHaveLength(2);
+    expect(cells[0]).toMatchObject({ type: 'text', content: '# Hello' });
+    expect(cells[1]).toMatchObject({ type: 'code', content: 'show(1);' });
+  });
+
+  it('derives the default output name from a named markdown file', async () => {
+    await run(['import', 'docs/notes.md']);
+
+    expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(
+      path.resolve(process.cwd(), 'docs/notes.js')
+    );
+  });
+
+  it('-o picks the output path and the success message points serve at it', async () => {
+    await run(['import', 'notes.md', '-o', 'out/nb.js']);
+
+    expect(vi.mocked(fs.writeFile).mock.calls[0][0]).toBe(
+      path.resolve(process.cwd(), 'out/nb.js')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('my-scrapbook serve out/nb.js')
+    );
+  });
+
+  it('refuses to overwrite the markdown file itself, before reading anything', async () => {
+    await expect(
+      run(['import', 'notes.md', '-o', 'notes.md'])
+    ).rejects.toThrow('exit:1');
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('would overwrite the markdown file itself')
+    );
+    expect(fs.readFile).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses to overwrite an existing notebook without -f', async () => {
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    await expect(run(['import'])).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('notebook.js already exists')
+    );
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('-f overwrites an existing notebook', async () => {
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    await run(['import', '-f']);
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a missing markdown file and exits 1', async () => {
+    vi.mocked(fs.readFile).mockRejectedValueOnce(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    await expect(run(['import', 'missing.md'])).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('No markdown file found at missing.md')
+    );
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects excess arguments', async () => {
+    await expect(run(['import', 'a.md', 'b.md'])).rejects.toMatchObject({
+      code: 'commander.excessArguments',
+    });
+    expect(fs.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/jbook/packages/cli/src/commands/import.ts
+++ b/jbook/packages/cli/src/commands/import.ts
@@ -1,0 +1,77 @@
+import fs from "fs/promises";
+import path from "path";
+import { Command } from "commander";
+import { markdownToCells } from "../markdown";
+
+export const importCommand = new Command()
+  .command("import [filename]")
+  .description(
+    "Create a notebook from a markdown file (default: notebook.md)"
+  )
+  .option(
+    "-o, --out <file>",
+    "notebook file to write (default: the markdown name with .js)"
+  )
+  .option("-f, --force", "overwrite the output notebook if it already exists")
+  .action(
+    async (
+      filename = "notebook.md",
+      options: { out?: string; force?: boolean }
+    ) => {
+      const inputPath = path.resolve(process.cwd(), filename);
+      const outFile = options.out ?? filename.replace(/\.[^./\\]*$/, "") + ".js";
+      const outPath = path.resolve(process.cwd(), outFile);
+
+      if (outPath === inputPath) {
+        console.error(
+          `The output file would overwrite the markdown file itself (${filename}). Pick a different -o path.`
+        );
+        process.exit(1);
+      }
+
+      let raw: string;
+      try {
+        raw = await fs.readFile(inputPath, "utf-8");
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          console.error(`No markdown file found at ${filename}.`);
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Could not read ${filename}: ${message}`);
+        }
+        process.exit(1);
+      }
+
+      // Notebooks are user data: never silently replace one.
+      if (!options.force) {
+        let exists = true;
+        try {
+          await fs.access(outPath);
+        } catch {
+          exists = false;
+        }
+        if (exists) {
+          console.error(
+            `${outFile} already exists. Pass -f to overwrite it, or -o to pick a different name.`
+          );
+          process.exit(1);
+        }
+      }
+
+      try {
+        const cells = markdownToCells(raw);
+        await fs.writeFile(outPath, JSON.stringify(cells), "utf-8");
+        const codeCount = cells.filter((cell) => cell.type === "code").length;
+        console.log(
+          `Imported ${filename} to ${outFile} (${codeCount} code, ${
+            cells.length - codeCount
+          } text cells). Run "my-scrapbook serve ${outFile}" to open it.`
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Could not import ${filename}: ${message}`);
+        process.exit(1);
+      }
+    }
+  );

--- a/jbook/packages/cli/src/index.ts
+++ b/jbook/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { program } from 'commander';
 import { serveCommand } from './commands/serve';
 import { exportCommand } from './commands/export';
+import { importCommand } from './commands/import';
 
 // Resolved at runtime relative to dist/index.js (esbuild inlines it into the
 // published bundle), so the reported version always matches the package.
@@ -17,5 +18,6 @@ program
 // serve is the default so a bare `npx my-scrapbook` opens the notebook.
 program.addCommand(serveCommand, { isDefault: true });
 program.addCommand(exportCommand);
+program.addCommand(importCommand);
 
 program.parse(process.argv);

--- a/jbook/packages/cli/src/markdown.test.ts
+++ b/jbook/packages/cli/src/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Cell } from '@my-scrapbook/types';
-import { cellsToMarkdown, parseNotebook } from './markdown';
+import { cellsToMarkdown, markdownToCells, parseNotebook } from './markdown';
 
 const cell = (type: Cell['type'], content: string, id = 'x'): Cell => ({
   id,
@@ -70,5 +70,96 @@ describe('cellsToMarkdown', () => {
 
   it('handles an empty notebook', () => {
     expect(cellsToMarkdown([])).toBe('\n');
+  });
+});
+
+describe('markdownToCells', () => {
+  const shapes = (cells: Cell[]) =>
+    cells.map(({ type, content }) => ({ type, content }));
+
+  it('turns JS/TS fences into code cells and the rest into text cells', () => {
+    const cells = markdownToCells(
+      '# Notes\n\nSome prose.\n\n```jsx\nshow(1);\n```\n\nMore prose.\n'
+    );
+    expect(shapes(cells)).toEqual([
+      { type: 'text', content: '# Notes\n\nSome prose.' },
+      { type: 'code', content: 'show(1);' },
+      { type: 'text', content: 'More prose.' },
+    ]);
+  });
+
+  it('accepts every JS/TS language tag, case-insensitively', () => {
+    for (const lang of ['js', 'jsx', 'ts', 'tsx', 'JavaScript', 'TypeScript']) {
+      const cells = markdownToCells(`\`\`\`${lang}\nshow(1);\n\`\`\`\n`);
+      expect(cells).toHaveLength(1);
+      expect(cells[0].type).toBe('code');
+    }
+  });
+
+  it('keeps other-language fences inside text cells, fences included', () => {
+    const cells = markdownToCells(
+      'Prose\n\n```python\nprint(1)\n```\n\nAfter\n'
+    );
+    expect(shapes(cells)).toEqual([
+      {
+        type: 'text',
+        content: 'Prose\n\n```python\nprint(1)\n```\n\nAfter',
+      },
+    ]);
+  });
+
+  it('does not mistake a jsx opener inside a longer non-code fence for a cell', () => {
+    const md = '````\n```jsx\nnot a cell\n```\n````\n';
+    const cells = markdownToCells(md);
+    expect(shapes(cells)).toEqual([
+      { type: 'text', content: '````\n```jsx\nnot a cell\n```\n````' },
+    ]);
+  });
+
+  it('handles lengthened fences around code containing backtick runs', () => {
+    const cells = markdownToCells('````jsx\nconst md = `\n```js\n`;\n````\n');
+    expect(shapes(cells)).toEqual([
+      { type: 'code', content: 'const md = `\n```js\n`;' },
+    ]);
+  });
+
+  it('treats an unclosed fence as running to the end of the file', () => {
+    const cells = markdownToCells('```js\nshow(1);\nshow(2);\n');
+    expect(shapes(cells)).toEqual([
+      { type: 'code', content: 'show(1);\nshow(2);' },
+    ]);
+  });
+
+  it('normalizes CRLF line endings', () => {
+    const cells = markdownToCells('# Hi\r\n\r\n```js\r\nshow(1);\r\n```\r\n');
+    expect(shapes(cells)).toEqual([
+      { type: 'text', content: '# Hi' },
+      { type: 'code', content: 'show(1);' },
+    ]);
+  });
+
+  it('produces no cells for empty or blank markdown', () => {
+    expect(markdownToCells('')).toEqual([]);
+    expect(markdownToCells('\n\n  \n')).toEqual([]);
+  });
+
+  it('assigns each cell a unique non-empty id', () => {
+    const cells = markdownToCells('a\n\n```js\n1\n```\n\nb\n');
+    const ids = cells.map((c) => c.id);
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('round-trips a notebook through export and back', () => {
+    const original: Cell[] = [
+      cell('text', '# Title\n\nProse with `inline code`.'),
+      cell('code', "import axios from 'axios';\nshow(axios);"),
+      cell('code', 'const md = `\n```js\n`;'),
+      cell('text', 'The end.'),
+    ];
+    const back = markdownToCells(cellsToMarkdown(original));
+    expect(shapes(back)).toEqual(
+      original.map(({ type, content }) => ({ type, content }))
+    );
   });
 });

--- a/jbook/packages/cli/src/markdown.ts
+++ b/jbook/packages/cli/src/markdown.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { Cell } from "@my-scrapbook/types";
 
 // Parses the raw contents of a notebook file, throwing a descriptive error if
@@ -37,6 +38,96 @@ const fenceFor = (content: string): string => {
     0
   );
   return "`".repeat(Math.max(3, longestRun + 1));
+};
+
+// Languages whose fenced blocks become code cells on import. Anything else
+// (python, bash, no language) stays inside the surrounding text cell, where
+// the app renders it as a plain markdown code block.
+const CODE_CELL_LANGS = new Set([
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "javascript",
+  "typescript",
+]);
+
+// A backtick fence opener at the start of a line; CommonMark forbids
+// backticks in the info string of a backtick fence, so [^`]* is exact.
+const FENCE_OPEN = /^(`{3,})([^`]*)$/;
+
+const stripBlankEdges = (lines: string[]): string => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start].trim() === "") start++;
+  while (end > start && lines[end - 1].trim() === "") end--;
+  return lines.slice(start, end).join("\n").trimEnd();
+};
+
+// Turns a markdown document into notebook cells — the inverse of
+// cellsToMarkdown. JS/TS fenced blocks become code cells; everything between
+// them becomes text cells.
+export const markdownToCells = (markdown: string): Cell[] => {
+  const lines = markdown.split(/\r\n|\r|\n/);
+  const cells: Cell[] = [];
+  let textRun: string[] = [];
+
+  const flushText = () => {
+    const content = stripBlankEdges(textRun);
+    textRun = [];
+    if (content !== "") {
+      cells.push({ id: randomUUID(), type: "text", content });
+    }
+  };
+
+  // Reads a fenced block's body starting at lines[i], up to a closing fence
+  // (at least as long as the opener with nothing else on the line — the
+  // CommonMark rule) or end of input, per CommonMark's unclosed-block rule.
+  const readFence = (i: number, fence: string) => {
+    const body: string[] = [];
+    while (i < lines.length) {
+      const close = lines[i].match(/^(`{3,})\s*$/);
+      if (close && close[1].length >= fence.length) {
+        return { body, closeLine: lines[i], next: i + 1 };
+      }
+      body.push(lines[i]);
+      i++;
+    }
+    return { body, closeLine: null, next: i };
+  };
+
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(FENCE_OPEN);
+    if (!open) {
+      textRun.push(lines[i]);
+      i++;
+      continue;
+    }
+
+    const [, fence, info] = open;
+    const lang = info.trim().split(/\s+/)[0].toLowerCase();
+    const block = readFence(i + 1, fence);
+    if (CODE_CELL_LANGS.has(lang)) {
+      flushText();
+      cells.push({
+        id: randomUUID(),
+        type: "code",
+        content: block.body.join("\n").trimEnd(),
+      });
+    } else {
+      // A non-code fence is consumed whole into the text run, so a JS/TS
+      // opener appearing inside it can't be mistaken for a code cell.
+      textRun.push(lines[i], ...block.body);
+      if (block.closeLine !== null) {
+        textRun.push(block.closeLine);
+      }
+    }
+    i = block.next;
+  }
+  flushText();
+
+  return cells;
 };
 
 export const cellsToMarkdown = (cells: Cell[]): string => {

--- a/jbook/packages/local-client/src/bundler/index.test.ts
+++ b/jbook/packages/local-client/src/bundler/index.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const esbuildMock = vi.hoisted(() => ({
+  version: '0.99.0',
+  initialize: vi.fn(),
+  build: vi.fn(),
+}));
+
+const cache = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+vi.mock('esbuild-wasm', () => esbuildMock);
+vi.mock('esbuild-wasm/esbuild.wasm?url', () => ({
+  default: '/assets/esbuild.wasm',
+}));
+vi.mock('localforage', () => ({
+  default: {
+    createInstance: () => cache,
+  },
+}));
+
+// bundle() caches initialization in module state, so each test gets a fresh
+// copy of the module.
+const loadBundle = async () => {
+  vi.resetModules();
+  return (await import('./index')).default;
+};
+
+describe('bundler initialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    esbuildMock.build.mockResolvedValue({ outputFiles: [{ text: 'bundled' }] });
+  });
+
+  it('initializes from the locally bundled wasm binary', async () => {
+    esbuildMock.initialize.mockResolvedValue(undefined);
+    const bundle = await loadBundle();
+
+    const result = await bundle('const a = 1;');
+
+    expect(result).toEqual({ code: 'bundled', err: '' });
+    expect(esbuildMock.initialize).toHaveBeenCalledTimes(1);
+    expect(esbuildMock.initialize).toHaveBeenCalledWith({
+      wasmURL: '/assets/esbuild.wasm',
+      worker: true,
+    });
+  });
+
+  it('initializes only once across bundles', async () => {
+    esbuildMock.initialize.mockResolvedValue(undefined);
+    const bundle = await loadBundle();
+
+    await bundle('1');
+    await bundle('2');
+
+    expect(esbuildMock.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to unpkg, pinned to the installed version, if the local wasm fails', async () => {
+    esbuildMock.initialize
+      .mockRejectedValueOnce(new Error('failed to fetch wasm'))
+      .mockResolvedValueOnce(undefined);
+    const bundle = await loadBundle();
+
+    const result = await bundle('const a = 1;');
+
+    expect(result).toEqual({ code: 'bundled', err: '' });
+    expect(esbuildMock.initialize).toHaveBeenCalledTimes(2);
+    expect(esbuildMock.initialize).toHaveBeenLastCalledWith({
+      wasmURL: 'https://unpkg.com/esbuild-wasm@0.99.0/esbuild.wasm',
+      worker: true,
+    });
+  });
+
+  it('reports the error and allows a retry when both sources fail', async () => {
+    esbuildMock.initialize
+      .mockRejectedValueOnce(new Error('local failed'))
+      .mockRejectedValueOnce(new Error('unpkg failed'))
+      .mockResolvedValueOnce(undefined);
+    const bundle = await loadBundle();
+
+    const failed = await bundle('const a = 1;');
+    expect(failed.code).toBe('');
+    expect(failed.err).toBe('unpkg failed');
+
+    // The failed initialization is not cached: the next bundle retries.
+    const retried = await bundle('const a = 1;');
+    expect(retried).toEqual({ code: 'bundled', err: '' });
+  });
+});

--- a/jbook/packages/local-client/src/bundler/index.ts
+++ b/jbook/packages/local-client/src/bundler/index.ts
@@ -7,12 +7,18 @@ import type { BundleResult } from "@my-scrapbook/types";
 import { unpkgPathPlugin } from "./plugins/unpkg-path-plugin";
 import { fetchPlugin } from "./plugins/fetch-plugin";
 
+// If the local binary can't be loaded (e.g. a corrupted install), fall back
+// to unpkg, pinned to the installed package's version so the binary still
+// matches the JS API.
+const fallbackWasmURL = `https://unpkg.com/esbuild-wasm@${esbuild.version}/esbuild.wasm`;
+
 let initPromise: Promise<void> | null = null;
 
 const ensureInitialized = () => {
   if (!initPromise) {
     initPromise = esbuild
       .initialize({ wasmURL, worker: true })
+      .catch(() => esbuild.initialize({ wasmURL: fallbackWasmURL, worker: true }))
       .catch((err) => {
         // Allow a later bundle() call to retry initialization.
         initPromise = null;

--- a/jbook/scripts/pack-smoke.sh
+++ b/jbook/scripts/pack-smoke.sh
@@ -75,7 +75,9 @@ npm install "$CLI_TGZ" --no-audit --no-fund --loglevel=error
 BIN="$APP/node_modules/.bin/my-scrapbook"
 
 echo "==> Checking --version"
-EXPECTED="$(node -p "require('$ROOT/packages/cli/package.json').version")"
+# The path is passed as an argument (not interpolated into the expression) so
+# Git Bash on Windows converts it to a form Windows node can require().
+EXPECTED="$(node -p "require(process.argv[1]).version" "$ROOT/packages/cli/package.json")"
 ACTUAL="$("$BIN" --version)"
 if [ "$ACTUAL" != "$EXPECTED" ]; then
   echo "--version reported '$ACTUAL', expected '$EXPECTED'" >&2


### PR DESCRIPTION
The feature set for the next release (changelog under **Unreleased**).

## Markdown import

`npx my-scrapbook import notes.md` — the inverse of `export`:

- Fenced `js` / `jsx` / `ts` / `tsx` blocks (case-insensitive) become code cells; everything between them becomes text cells; fenced blocks in other languages stay inside text cells as ordinary markdown.
- CommonMark fence semantics: lengthened fences (`````` ````jsx ``````), closers at least as long as the opener, unclosed fences running to end of file, CRLF input, and a JS opener inside a longer non-code fence is not mistaken for a cell.
- Output defaults to the markdown name with `.js`; `-o` picks another path; an existing notebook is never overwritten without `-f`.
- `export` → `import` round trip leaves a notebook unchanged — asserted by a test and verified against the built binary.

## esbuild.wasm fallback (closes the last of TODO item 9)

If the locally bundled binary fails to load, the bundler retries from unpkg pinned to the installed `esbuild-wasm` version, so the binary always matches the JS API. A failed initialization still isn't cached; the next bundle retries both sources. New 4-test suite around init caching, fallback, and retry.

## CI support matrix

- Node 20 / 22 / 24 on Linux, plus Node 22 on Windows and macOS — build, unit tests, and the pack-and-install smoke test on every job (`fail-fast: false`).
- `shell: bash` set globally so the existing steps run unchanged on Windows.
- `pack-smoke.sh`: the one non-portable line (absolute path interpolated into a `node -p` expression) now passes the path as an argument so Git Bash path-conversion applies. **The Windows/macOS jobs get their first real exercise on this PR's checks** — reviewed for MSYS pitfalls but not runnable locally.
- `live` has no branch protection, so the renamed matrix check names break nothing.

## Docs & hygiene

- README: "Import a notebook from Markdown", "Works offline" (documenting the mostly pre-existing offline story + the new fallback), "What's new in 3.11".
- TODO.md: checkboxes that had already shipped (UUID uniqueness test, invalid-input API tests, `useCumulativeCode` memoization) marked done with pointers to where they landed.

## Verification

- 161 tests pass across the three packages (22 new: 10 parser, 8 import command, 4 bundler init — one pre-existing bundler test file was extended).
- `npm run smoke` passes end to end with the modified script.
- Built CLI exercised by hand: import, `-f` guard, `-o`, `--help`, and a byte-identical export/import round trip.
