### PR TITLE
Prepare the 3.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.11.0 — 2026-08-02
 
 ### Added
 - **Markdown import.** `my-scrapbook import notes.md` creates a notebook from a markdown file — the inverse of `export`. Fenced `js`/`jsx`/`ts`/`tsx` blocks (case-insensitive, any CommonMark fence length, unclosed fences run to end of file) become code cells; everything between them becomes text cells, with fenced blocks in other languages kept as markdown inside them. Output defaults to the markdown name with `.js`, `-o` picks another path, and an existing notebook is never overwritten without `-f`. A notebook survives `export` → `import` unchanged (verified by a round-trip test).

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.10.2"
+  "version": "3.11.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.10.2",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.10.1",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.11.0 (the feature work merged in #59):

- `my-scrapbook` 3.10.2 → **3.11.0** (markdown import)
- `@my-scrapbook/local-client` 3.10.1 → **3.11.0** (esbuild.wasm unpkg fallback)
- `local-api` stays 3.8.0, `types` stays 3.0.0; `lerna.json` and `package-lock.json` sync
- CHANGELOG: Unreleased → **3.11.0 — 2026-08-02**

Verified locally: all 161 tests green across the matrix-relevant packages, and `npm run smoke` packs, installs, and runs the CLI end-to-end reporting **3.11.0**.

After merge: push the `v3.11.0` tag — `publish.yml` publishes both new versions to npm with provenance (packages already on the registry are skipped).