### PR TITLE
Tolerate legacy JS object-literal notebooks in GET /cells

### DIFF
--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -8150,7 +8150,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -15109,6 +15108,7 @@
         "@my-scrapbook/local-client": "^3.0.0",
         "express": "^5.2.1",
         "http-proxy-middleware": "^3.0.7",
+        "json5": "^2.2.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/jbook/packages/local-api/package.json
+++ b/jbook/packages/local-api/package.json
@@ -36,6 +36,7 @@
     "@my-scrapbook/local-client": "^3.0.0",
     "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.7",
+    "json5": "^2.2.3",
     "zod": "^4.4.3"
   },
   "repository": {

--- a/jbook/packages/local-api/src/routes/cells.test.ts
+++ b/jbook/packages/local-api/src/routes/cells.test.ts
@@ -43,6 +43,41 @@ describe("cells router", () => {
       expect(res.body).toEqual(cells);
     });
 
+    it("reads legacy notebooks written in relaxed JS object-literal syntax", async () => {
+      // Format written by pre-3.x versions of the app: unquoted keys,
+      // trailing commas, and a trailing semicolon.
+      const legacy = `[
+  {
+    content: "**Hello** markdown cell",
+    type: "text",
+    id: "qw4rr",
+  },
+  {
+    content: "show(1);\\r\\n",
+    type: "code",
+    id: "ldq45",
+  },
+];
+`;
+      await fs.writeFile(notebookPath(), legacy, "utf-8");
+
+      const res = await request(app).get("/cells");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([
+        { content: "**Hello** markdown cell", type: "text", id: "qw4rr" },
+        { content: "show(1);\r\n", type: "code", id: "ldq45" },
+      ]);
+    });
+
+    it("answers 500 when the file parses but is not a cell list", async () => {
+      await fs.writeFile(notebookPath(), '{"not": "cells"}', "utf-8");
+
+      const res = await request(app).get("/cells");
+      expect(res.status).toBe(500);
+      expect(res.body.error).toContain(FILENAME);
+    });
+
     it("answers 500 for a corrupted notebook instead of crashing", async () => {
       await fs.writeFile(notebookPath(), "not json{{{", "utf-8");
 

--- a/jbook/packages/local-api/src/routes/cells.ts
+++ b/jbook/packages/local-api/src/routes/cells.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import fs from "fs/promises";
 import path from "path";
+import JSON5 from "json5";
 import { z } from "zod";
 import { Cell, SaveCellsRequest, SaveCellsResponse } from "@my-scrapbook/types";
 
@@ -15,6 +16,34 @@ const cellSchema: z.ZodType<Cell> = z.object({
 const saveCellsRequestSchema: z.ZodType<SaveCellsRequest> = z.object({
   cells: z.array(cellSchema),
 });
+
+const notebookSchema: z.ZodType<Cell[]> = z.array(cellSchema);
+
+// Notebooks written by pre-3.x versions of the app are JS object-literal
+// syntax (unquoted keys, trailing commas, trailing semicolon) rather than
+// strict JSON, which is what the save path writes today. JSON5 covers the
+// object-literal relaxations; the trailing semicolon has to be stripped
+// separately since even JSON5 rejects it.
+const parseNotebookFile = (raw: string): Cell[] => {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    try {
+      data = JSON5.parse(raw.replace(/;\s*$/, ""));
+    } catch {
+      throw new Error("the file is not a valid notebook (unparseable)");
+    }
+  }
+
+  const parsed = notebookSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(
+      "the file parsed but does not contain a list of notebook cells"
+    );
+  }
+  return parsed.data;
+};
 
 // Explicit body size limit; the express default (100kb) is small enough that
 // a large notebook could fail to save.
@@ -31,7 +60,7 @@ export const createCellsRouter = (filename: string, dir: string) => {
       // Read the file
       const result = await fs.readFile(fullPath, { encoding: "utf-8" });
 
-      res.send(JSON.parse(result));
+      res.send(parseNotebookFile(result));
     } catch (err: any) {
       if (err.code === "ENOENT") {
         await fs.writeFile(fullPath, "[]", "utf-8");


### PR DESCRIPTION
## Summary
Re-implements work rescued from a stale worktree (`legacy-notebook-json5-parsing.patch`, written against the pre-history-rewrite 3.1.0 tree) on the current `live` codebase.

Notebooks written by pre-3.x versions of My Scrapbook use relaxed JS object-literal syntax — unquoted keys, trailing commas, and a trailing semicolon — rather than the strict JSON the save path writes today. Opening one of those notebooks made `GET /cells` answer a 500.

- `GET /cells` now tries strict `JSON.parse` first, then falls back to JSON5 parsing with the trailing semicolon stripped (even JSON5 rejects it).
- Either way the result is validated against the cell schema with zod, so a file that parses but isn't a cell list still answers a JSON 500 instead of being echoed to the client.
- Adds `json5` as a runtime dependency of `@my-scrapbook/local-api` (it was already in the tree as a transitive dev dependency, so the lockfile change is minimal).
- The parser is named `parseNotebookFile` to avoid confusion with the CLI's existing strict `parseNotebook` in `packages/cli/src/markdown.ts`.

The rescued `.patch` file was untracked in the repo root, so it has no commit to revert here; it is deleted from disk as part of landing this PR.

## Testing
- `npm test` in `jbook/`: 23 files, 111 tests, all passing (includes two new tests: legacy-syntax round-trip and parseable-but-not-a-cell-list 500).
- `npx tsc --noEmit` in `packages/local-api` passes.