### PR TITLE
Add a hosted zero-install demo, deployed to Vercel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Hosted demo.** [try-my-scrapbook.vercel.app](https://try-my-scrapbook.vercel.app) is the app with nothing to install: a new demo build (`npm run build:demo` in local-client, `vite build --mode demo` underneath) swaps the local API for browser persistence — the notebook is stored whole in IndexedDB, the same mechanism the module cache already uses. Notebook persistence now sits behind a two-function adapter (`src/persistence/`) chosen at build time; the CLI build's behavior is unchanged. A first visit opens on a seeded sample notebook (persisted immediately, so deleting every cell stays deleted), the header labels it "demo notebook" and gains **Get the CLI** and **Download notebook.js** buttons — the download is the exact JSON shape `npx my-scrapbook` opens — and the empty-state/guide copy says the notebook saves in the browser. Deploys from `jbook/` via the Vercel CLI (`vercel deploy --prod`; config in `jbook/vercel.json`, where the install pins `--include=dev` because Vercel builds set `NODE_ENV=production`).
+
+### Fixed
+- `jbook/.gitignore` had lost a newline (`node_modulescoverage`), so `coverage/` output was never actually ignored.
+
 ## 3.11.0 — 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 - React and ReactDOM are already imported and ready for use.
 - All of your text and code are automatically saved to a file named notebook.js
 
+## Try it in your browser — nothing to install
+
+- A hosted demo runs at **[try-my-scrapbook.vercel.app](https://try-my-scrapbook.vercel.app)**: the same app, with the notebook saved in your browser instead of a file.
+- It opens on a sample notebook you can edit, and **Download notebook.js** in the header hands you a file the CLI opens as-is — so you can start in the demo and keep going locally.
+- The demo is `jbook/packages/local-client` built with `npm run build:demo` (deploy config in `jbook/vercel.json`).
+
 ## Install Instructions.
 
 - You'll need [Node.js](https://nodejs.org/) 20 or newer.

--- a/jbook/.gitignore
+++ b/jbook/.gitignore
@@ -1,3 +1,5 @@
 build
 dist
-node_modulescoverage
+node_modules
+coverage
+.vercel

--- a/jbook/packages/local-client/index.html
+++ b/jbook/packages/local-client/index.html
@@ -5,7 +5,10 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#f3f2f2" />
-    <meta name="description" content="Web site created using my-scrapbook" />
+    <meta
+      name="description"
+      content="My Scrapbook — an interactive JavaScript/TypeScript notebook. Write code and markdown side by side; bundling, previews, and npm imports all run in your browser."
+    />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>My ScrapBook</title>

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",
+    "build:demo": "tsc && vite build --mode demo",
     "preview": "vite preview",
     "prepublishOnly": "npm run build",
     "test": "vitest run",

--- a/jbook/packages/local-client/src/components/cell-list.tsx
+++ b/jbook/packages/local-client/src/components/cell-list.tsx
@@ -20,6 +20,7 @@ import { selectCells } from "../state";
 import SortableCell from "./sortable-cell";
 import AddCell from "./add-cell";
 import ExplainerText from "./example-text";
+import { IS_DEMO } from "../demo-mode";
 import { useActions } from "../hooks/use-actions";
 
 const GUIDE_STORAGE_KEY = "scrapbook.guideOpen";
@@ -108,8 +109,14 @@ const CellList: React.FC = () => {
           </button>
         </div>
         <p className="empty-footnote">
-          Saving to <span className="empty-file">notebook.js</span> in the
-          folder you started from.
+          {IS_DEMO ? (
+            <>Saving in this browser — nothing to install.</>
+          ) : (
+            <>
+              Saving to <span className="empty-file">notebook.js</span> in the
+              folder you started from.
+            </>
+          )}
         </p>
       </section>
     );

--- a/jbook/packages/local-client/src/components/example-text.tsx
+++ b/jbook/packages/local-client/src/components/example-text.tsx
@@ -1,5 +1,6 @@
 import "./example-text.css";
 import React from "react";
+import { IS_DEMO } from "../demo-mode";
 
 // The "How this works" strip that the meta bar's disclosure toggles open —
 // a tightened rewrite of the old permanent explainer wall.
@@ -24,7 +25,11 @@ const ExplainerText: React.FC = () => {
     <section className="guide-strip">
       <div className="guide-intro">
         <h4>Coding and documentation, in one file</h4>
-        <p>Everything you write saves to notebook.js.</p>
+        <p>
+          {IS_DEMO
+            ? 'Everything you write saves in this browser.'
+            : 'Everything you write saves to notebook.js.'}
+        </p>
       </div>
       <ol className="guide-items">
         {GUIDE_ITEMS.map((item, index) => (

--- a/jbook/packages/local-client/src/components/notebook-header.demo.test.tsx
+++ b/jbook/packages/local-client/src/components/notebook-header.demo.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithStore, makeStore } from '../test-utils';
+import { ThemeProvider } from '../theme-context';
+import type { Cell } from '../state/cell';
+
+// Force the demo build's view of the header; the default-mode header is
+// covered alongside the rest of the app's component tests.
+vi.mock('../demo-mode', () => ({ IS_DEMO: true }));
+
+import NotebookHeader from './notebook-header';
+
+const cells: Cell[] = [
+  { id: 't1', type: 'text', content: '# Hello' },
+  { id: 'c1', type: 'code', content: 'show(1)' },
+];
+
+describe('notebook header in demo mode', () => {
+  let downloaded: { name: string; body: string } | null;
+
+  beforeEach(() => {
+    downloaded = null;
+    // jsdom implements neither object URLs nor navigation; capture the blob
+    // at the point it would become a download.
+    URL.createObjectURL = vi.fn(() => 'blob:fake');
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+      async function (this: HTMLAnchorElement) {
+        const blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
+          .calls[0][0] as Blob;
+        downloaded = { name: this.download, body: await blob.text() };
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderHeader = () =>
+    renderWithStore(
+      <ThemeProvider>
+        <NotebookHeader />
+      </ThemeProvider>,
+      makeStore(cells)
+    );
+
+  it('labels the notebook as the demo and links to the CLI on npm', () => {
+    renderHeader();
+
+    expect(screen.getByText('demo notebook')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Get the CLI' })).toHaveAttribute(
+      'href',
+      'https://www.npmjs.com/package/my-scrapbook'
+    );
+  });
+
+  it('downloads the notebook as CLI-compatible notebook.js JSON', async () => {
+    renderHeader();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Download notebook.js' })
+    );
+    await vi.waitFor(() => expect(downloaded).not.toBeNull());
+
+    expect(downloaded!.name).toBe('notebook.js');
+    // The CLI's serve command reads exactly this shape from notebook.js.
+    expect(JSON.parse(downloaded!.body)).toEqual(cells);
+  });
+});

--- a/jbook/packages/local-client/src/components/notebook-header.tsx
+++ b/jbook/packages/local-client/src/components/notebook-header.tsx
@@ -7,7 +7,9 @@ import { useActions } from '../hooks/use-actions';
 import { selectCells } from '../state';
 import { cumulativeCodeFor } from '../hooks/use-cumulative-code';
 import { PERSIST_SAVE_DEBOUNCE_MS, NOTEBOOK_FILENAME } from '../constants';
+import { IS_DEMO } from '../demo-mode';
 import { exportNotebookHtml } from '../export/export-notebook';
+import { downloadFile } from '../export/download';
 import OfflineStatus from './offline-status';
 import UndoRedoBar from './undo-redo-bar';
 
@@ -58,6 +60,13 @@ const NotebookHeader: React.FC = () => {
     }
   };
 
+  // notebook.js is JSON despite the extension — the CLI's serve command
+  // reads exactly this shape, so a downloaded demo notebook opens as-is.
+  const onDownloadNotebook = () => {
+    const cells = present.order.map((id) => present.data[id]);
+    downloadFile(JSON.stringify(cells), NOTEBOOK_FILENAME, 'application/json');
+  };
+
   const [exportState, setExportState] = useState<
     'idle' | 'exporting' | 'failed'
   >('idle');
@@ -86,7 +95,16 @@ const NotebookHeader: React.FC = () => {
       <span className="brand-name">MY SCRAPBOOK</span>
       <span className="header-divider" aria-hidden="true" />
       <span className="file-meta">
-        <span className="file-name">{NOTEBOOK_FILENAME}</span>
+        <span
+          className="file-name"
+          title={
+            IS_DEMO
+              ? 'This is the hosted demo — the notebook is saved in this browser. Download notebook.js to take it to the CLI.'
+              : undefined
+          }
+        >
+          {IS_DEMO ? 'demo notebook' : NOTEBOOK_FILENAME}
+        </span>
         <span className="save-state label">
           {saving ? 'Saving…' : savedAt ? `Saved · ${formatTime(savedAt)}` : ''}
         </span>
@@ -106,6 +124,26 @@ const NotebookHeader: React.FC = () => {
       >
         {theme === 'light' ? <Moon size={15} /> : <Sun size={15} />}
       </button>
+      {IS_DEMO && (
+        <>
+          <a
+            className="btn btn-secondary get-cli"
+            href="https://www.npmjs.com/package/my-scrapbook"
+            target="_blank"
+            rel="noreferrer"
+            title="The full version runs locally, saves plain files, and converts notebooks to and from markdown"
+          >
+            Get the CLI
+          </a>
+          <button
+            className="btn btn-secondary download-notebook"
+            onClick={onDownloadNotebook}
+            title="Download this notebook as notebook.js — drop it in a folder and `npx my-scrapbook` opens it"
+          >
+            Download notebook.js
+          </button>
+        </>
+      )}
       <button
         className="btn btn-secondary export-html"
         onClick={onExportHtml}

--- a/jbook/packages/local-client/src/demo-mode.ts
+++ b/jbook/packages/local-client/src/demo-mode.ts
@@ -1,0 +1,5 @@
+// The demo build (`vite build --mode demo`) is the hosted, zero-install
+// version of the app: no local API, so the notebook persists to the browser
+// (IndexedDB) instead of a notebook.js file. Everything else — the editor,
+// bundler, and npm module fetching — already runs entirely in the browser.
+export const IS_DEMO = import.meta.env.MODE === 'demo';

--- a/jbook/packages/local-client/src/export/download.ts
+++ b/jbook/packages/local-client/src/export/download.ts
@@ -1,0 +1,13 @@
+// Hands content to the browser as a file download via a temporary object URL.
+export const downloadFile = (
+  content: string,
+  filename: string,
+  type: string
+): void => {
+  const url = URL.createObjectURL(new Blob([content], { type }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+};

--- a/jbook/packages/local-client/src/export/export-notebook.ts
+++ b/jbook/packages/local-client/src/export/export-notebook.ts
@@ -3,15 +3,7 @@ import { cumulativeCodeFor } from '../hooks/use-cumulative-code';
 import { bundleWithCache } from '../bundler/bundle-with-cache';
 import { renderMarkdownToHtml } from './render-markdown';
 import { buildExportHtml, ExportCell } from './export-html';
-
-const downloadHtml = (html: string, filename: string): void => {
-  const url = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(url);
-};
+import { downloadFile } from './download';
 
 // Assembles a self-contained HTML file from the notebook and hands it to the
 // browser as a download. Code cells are bundled exactly as the app bundles
@@ -41,5 +33,5 @@ export const exportNotebookHtml = async (
     }
   }
 
-  downloadHtml(buildExportHtml(items, new Date()), filename);
+  downloadFile(buildExportHtml(items, new Date()), filename, 'text/html');
 };

--- a/jbook/packages/local-client/src/persistence/browser.test.ts
+++ b/jbook/packages/local-client/src/persistence/browser.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Cell } from '../state/cell';
+
+const store = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+}));
+
+vi.mock('localforage', () => ({
+  default: {
+    createInstance: () => store,
+  },
+}));
+
+import { loadCells, saveCells } from './browser';
+import { demoSeedCells } from './demo-seed';
+
+describe('browser persistence', () => {
+  beforeEach(() => {
+    store.getItem.mockReset();
+    store.setItem.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('returns the stored notebook when one exists', async () => {
+    const cells: Cell[] = [{ id: 'a', type: 'code', content: 'show(1)' }];
+    store.getItem.mockResolvedValue(cells);
+
+    await expect(loadCells()).resolves.toEqual(cells);
+    expect(store.setItem).not.toHaveBeenCalled();
+  });
+
+  it('seeds and persists the sample notebook on first visit', async () => {
+    store.getItem.mockResolvedValue(null);
+
+    await expect(loadCells()).resolves.toEqual(demoSeedCells);
+    // Persisted immediately: deleting every cell must stay deleted rather
+    // than resurrecting the samples on the next load.
+    expect(store.setItem).toHaveBeenCalledWith('cells', demoSeedCells);
+  });
+
+  it('does not re-seed an emptied notebook', async () => {
+    store.getItem.mockResolvedValue([]);
+
+    await expect(loadCells()).resolves.toEqual([]);
+    expect(store.setItem).not.toHaveBeenCalled();
+  });
+
+  it('writes the whole notebook on save', async () => {
+    const cells: Cell[] = [
+      { id: 'a', type: 'text', content: '# hi' },
+      { id: 'b', type: 'code', content: 'show(2)' },
+    ];
+
+    await saveCells(cells);
+    expect(store.setItem).toHaveBeenCalledWith('cells', cells);
+  });
+});
+
+describe('demo seed', () => {
+  it('has unique ids and valid cell types', () => {
+    const ids = demoSeedCells.map((cell) => cell.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const cell of demoSeedCells) {
+      expect(['code', 'text']).toContain(cell.type);
+      expect(cell.content.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/jbook/packages/local-client/src/persistence/browser.ts
+++ b/jbook/packages/local-client/src/persistence/browser.ts
@@ -1,0 +1,29 @@
+import localForage from 'localforage';
+import type { Cell } from '../state/cell';
+import { demoSeedCells } from './demo-seed';
+
+// The demo build persists the notebook in the browser, using the same
+// IndexedDB mechanism as the module and bundle caches. The notebook is
+// stored whole under a single key — it is small JSON, and whole-notebook
+// writes mirror what the local API does with notebook.js.
+const notebookStore = localForage.createInstance({
+  name: 'notebook',
+});
+
+const CELLS_KEY = 'cells';
+
+export const loadCells = async (): Promise<Cell[]> => {
+  const stored = await notebookStore.getItem<Cell[]>(CELLS_KEY);
+  if (stored !== null) {
+    return stored;
+  }
+  // First visit: open on the sample notebook rather than an empty page. The
+  // seed is persisted immediately so that deleting every cell stays deleted
+  // instead of resurrecting the samples on reload.
+  await notebookStore.setItem(CELLS_KEY, demoSeedCells);
+  return demoSeedCells;
+};
+
+export const saveCells = async (cells: Cell[]): Promise<void> => {
+  await notebookStore.setItem(CELLS_KEY, cells);
+};

--- a/jbook/packages/local-client/src/persistence/demo-seed.ts
+++ b/jbook/packages/local-client/src/persistence/demo-seed.ts
@@ -1,0 +1,105 @@
+import type { Cell } from '../state/cell';
+
+// The notebook a first-time demo visitor lands on. The point of the demo is
+// watching code run, so it opens populated: the same explainer and samples
+// the README uses, plus a closing pointer to the CLI. IDs are only opaque
+// keys; fixed values keep the seed deterministic.
+export const demoSeedCells: Cell[] = [
+  {
+    id: 'demo-explainer',
+    type: 'text',
+    content: `**My Scrapbook**
+----------
+This is an interactive coding environment. Write JavaScript or TypeScript, see it run as you type, and keep the documentation right next to the code in markdown.
+
+- Click any text cell (including this one) to edit it
+- Cells share one file — a variable defined in cell #1 works in every cell below it
+- Call the built-in \`show()\` with a React component, string, number, or object to render it in the preview
+- \`console.log\` output shows up in a console panel under the preview
+- Import any npm package — bundling happens right in the browser, and packages you've used keep working offline
+- Click **Format** in any code cell and Prettier tidies it up
+- Reorder cells with the grip handle (or the arrows), and undo any of it with Ctrl/Cmd+Z
+
+This is the hosted demo, so everything you write is saved in this browser.`,
+  },
+  {
+    id: 'demo-typescript',
+    type: 'code',
+    content: `import { useState } from 'react';
+
+interface Task {
+  title: string;
+  done: boolean;
+}
+
+const initial: Task[] = [
+  { title: 'Write some TypeScript', done: true },
+  { title: 'Import an npm package', done: false },
+  { title: 'Drag a cell somewhere new', done: false },
+];
+
+const TaskList = () => {
+  const [tasks, setTasks] = useState(initial);
+  const toggle = (title: string) =>
+    setTasks(
+      tasks.map((t) => (t.title === title ? { ...t, done: !t.done } : t))
+    );
+
+  return (
+    <ul style={{ listStyle: 'none', padding: 4, fontFamily: 'sans-serif' }}>
+      {tasks.map((t) => (
+        <li
+          key={t.title}
+          onClick={() => toggle(t.title)}
+          style={{ cursor: 'pointer', padding: 2 }}
+        >
+          {t.done ? '✅' : '⬜️'} {t.title}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+console.log('tasks:', initial.map((t) => t.title));
+show(<TaskList />);`,
+  },
+  {
+    id: 'demo-npm-intro',
+    type: 'text',
+    content: `Any npm package works — including CSS. The cell below fetches live data with **axios** and styles it with **bulma**; both are fetched from unpkg and bundled right here in the browser.`,
+  },
+  {
+    id: 'demo-npm',
+    type: 'code',
+    content: `import axios from 'axios';
+import 'bulma/css/bulma.css';
+
+axios.get('https://jsonplaceholder.typicode.com/users').then(({ data }) => {
+  console.log('fetched', data.length, 'users');
+  show(
+    <div className="content m-4">
+      <h4>Team</h4>
+      <ul>
+        {data.slice(0, 4).map((user) => (
+          <li key={user.id}>
+            {user.name} — <em>{user.company.name}</em>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});`,
+  },
+  {
+    id: 'demo-outro',
+    type: 'text',
+    content: `**Like it? The real thing runs on your machine.**
+
+\`\`\`
+npm i my-scrapbook
+npx my-scrapbook
+\`\`\`
+
+The CLI saves your notebook as a plain \`notebook.js\` file in the folder you run it from, works fully offline, and can convert notebooks to and from markdown (\`npx my-scrapbook export\` / \`import\`). Use **Download notebook.js** in the header to take what you've written here with you.`,
+  },
+];

--- a/jbook/packages/local-client/src/persistence/index.ts
+++ b/jbook/packages/local-client/src/persistence/index.ts
@@ -1,0 +1,9 @@
+import { IS_DEMO } from '../demo-mode';
+import * as server from './server';
+import * as browser from './browser';
+
+// Where the notebook lives is the only difference between the CLI build and
+// the hosted demo: the local API's notebook file, or the browser's IndexedDB.
+// IS_DEMO is a build-time constant, so the unused implementation is dead code
+// to the bundler.
+export const persistence = IS_DEMO ? browser : server;

--- a/jbook/packages/local-client/src/persistence/server.ts
+++ b/jbook/packages/local-client/src/persistence/server.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import type { FetchCellsResponse, SaveCellsRequest } from '@my-scrapbook/types';
+import type { Cell } from '../state/cell';
+
+// The CLI build persists through @my-scrapbook/local-api, which reads and
+// writes the notebook file the server was started with.
+export const loadCells = async (): Promise<Cell[]> => {
+  const { data }: { data: FetchCellsResponse } = await axios.get('/cells');
+  return data;
+};
+
+export const saveCells = async (cells: Cell[]): Promise<void> => {
+  const body: SaveCellsRequest = { cells };
+  await axios.post('/cells', body);
+};

--- a/jbook/packages/local-client/src/state/cells-slice.ts
+++ b/jbook/packages/local-client/src/state/cells-slice.ts
@@ -1,8 +1,7 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { StateWithHistory } from 'redux-undo';
-import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
-import type { FetchCellsResponse, SaveCellsRequest } from '@my-scrapbook/types';
+import { persistence } from '../persistence';
 import { Cell, CellTypes } from './cell';
 
 export type Direction = 'up' | 'down';
@@ -23,9 +22,11 @@ const initialState: CellsState = {
   data: {},
 };
 
+// Persistence is behind an adapter: the CLI build talks to the local API,
+// the hosted demo build stores the notebook in the browser (see
+// ../persistence).
 export const fetchCells = createAsyncThunk('cells/fetchCells', async () => {
-  const { data }: { data: FetchCellsResponse } = await axios.get('/cells');
-  return data;
+  return persistence.loadCells();
 });
 
 // The state type is declared structurally instead of importing RootState from
@@ -45,8 +46,7 @@ export const saveCells = createAsyncThunk<
 
   const cells = order.map((id) => data[id]);
 
-  const body: SaveCellsRequest = { cells };
-  await axios.post('/cells', body);
+  await persistence.saveCells(cells);
 });
 
 const cellsSlice = createSlice({

--- a/jbook/vercel.json
+++ b/jbook/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "npm install --include=dev",
+  "buildCommand": "npm run build:demo --workspace @my-scrapbook/local-client",
+  "outputDirectory": "packages/local-client/build"
+}


### PR DESCRIPTION
## What

A hosted demo of My Scrapbook now runs at **https://try-my-scrapbook.vercel.app** — the app with nothing to install. This PR adds the demo build target and the small amount of code it needs; the CLI, API, and notebook file format are untouched.

## How

- **Persistence adapter** (`src/persistence/`): the two axios calls to the local API move behind a `loadCells`/`saveCells` interface. The CLI build keeps the server implementation; the demo build (`npm run build:demo`, i.e. `vite build --mode demo`, keyed by `IS_DEMO` in `src/demo-mode.ts`) stores the notebook whole in IndexedDB via localforage — the same mechanism the module cache already uses.
- **First-visit seeding**: the demo opens on a sample notebook (explainer, TypeScript task list, axios + bulma cell, closing CLI pitch). The seed is persisted immediately so deleting every cell stays deleted.
- **Demo-only UI**: the header shows "demo notebook" and gains **Get the CLI** (→ npm) and **Download notebook.js** — the download is the exact JSON shape `npx my-scrapbook` opens, so demo work carries over to the CLI. Empty-state and guide copy say the notebook saves in the browser.
- **Deploy**: `jbook/vercel.json`, deployed via the Vercel CLI from `jbook/` (project `my-scrapbook-demo`, production domain `try-my-scrapbook.vercel.app`). The install command pins `--include=dev` because Vercel builds set `NODE_ENV=production`, which would otherwise skip the build tooling.
- **Drive-by fix**: `jbook/.gitignore` had lost a newline (`node_modulescoverage`), leaving `coverage/` unignored.

## Testing

- New tests: browser-persistence seeding/round-trip/no-reseed, demo-seed validity, and a demo-mode header test proving the downloaded notebook.js parses back to the exact cells. Full suite: **118 passed**.
- Both build targets compile (`build` and `build:demo`).
- Verified the live production URL cold in a browser: seed loads, both code cells bundle through esbuild-wasm + unpkg (~2.6 s each), previews render, console clean.