### PR TITLE
Mobile responsive design for the notebook UI

### DIFF
--- a/jbook/packages/local-client/src/components/action-bar.css
+++ b/jbook/packages/local-client/src/components/action-bar.css
@@ -15,3 +15,13 @@
   opacity: 1;
   color: var(--color-accent);
 }
+
+/* Touch: bigger targets, and full strength since there's no hover to
+   promote them. */
+@media (pointer: coarse) {
+  .action-bar .cell-action {
+    width: 36px;
+    height: 36px;
+    opacity: 0.7;
+  }
+}

--- a/jbook/packages/local-client/src/components/cell-list.css
+++ b/jbook/packages/local-client/src/components/cell-list.css
@@ -121,3 +121,15 @@
 .drag-handle:active {
   cursor: grabbing;
 }
+
+@media (max-width: 768px) {
+  .notebook-meta {
+    padding: 10px 16px;
+  }
+  .cell-list {
+    padding: 0 16px 120px;
+  }
+  .empty-notebook {
+    padding: 48px 16px;
+  }
+}

--- a/jbook/packages/local-client/src/components/code-cell.css
+++ b/jbook/packages/local-client/src/components/code-cell.css
@@ -5,6 +5,23 @@
   border: 1px solid var(--color-divider);
 }
 
+/* Mobile: editor over preview, each half the cell height (flex-basis wins
+   over the editor's height: 100%). The cell's south handle still resizes
+   the whole. Breakpoint mirrors MOBILE_BREAKPOINT_PX in constants.ts. */
+.code-cell.stacked {
+  flex-direction: column;
+}
+
+.code-cell.stacked .editor-wrapper,
+.code-cell.stacked .preview-pane {
+  flex: 1 1 50%;
+  min-height: 0;
+}
+
+.code-cell.stacked .preview-pane {
+  border-top: 1px solid var(--color-divider);
+}
+
 /* Shared 32px pane toolbar (JAVASCRIPT / PREVIEW). */
 .pane-toolbar {
   display: flex;

--- a/jbook/packages/local-client/src/components/code-cell.tsx
+++ b/jbook/packages/local-client/src/components/code-cell.tsx
@@ -8,6 +8,7 @@ import { BUNDLE_DEBOUNCE_MS } from '../constants';
 import { useActions } from '../hooks/use-actions';
 import { useTypedSelector } from '../hooks/use-typed-selector';
 import { useCumulativeCode } from '../hooks/use-cumulative-code';
+import { useIsMobile } from '../hooks/use-media-query';
 
 interface CodeCellProps {
   cell: Cell;
@@ -50,15 +51,20 @@ const CodeCell: React.FC<CodeCellProps> = ({ cell }) => {
   const bundling = !bundle || bundle.loading;
   const display = bundling ? lastBundle : bundle;
 
+  // On mobile the panes stack vertically (CSS splits the height 50/50), so
+  // the horizontal editor/preview resizer has nothing to resize.
+  const isMobile = useIsMobile();
+  const editor = (
+    <CodeEditor
+      initialValue={cell.content}
+      onChange={(value) => updateCell(cell.id, value)}
+    />
+  );
+
   return (
     <Resizable direction="vertical">
-      <div className="code-cell">
-        <Resizable direction="horizontal">
-          <CodeEditor
-            initialValue={cell.content}
-            onChange={(value) => updateCell(cell.id, value)}
-          />
-        </Resizable>
+      <div className={isMobile ? 'code-cell stacked' : 'code-cell'}>
+        {isMobile ? editor : <Resizable direction="horizontal">{editor}</Resizable>}
         <div className="preview-pane">
           <div className="pane-toolbar preview-toolbar">
             <span className="label">Preview</span>

--- a/jbook/packages/local-client/src/components/code-editor.css
+++ b/jbook/packages/local-client/src/components/code-editor.css
@@ -40,6 +40,13 @@
   opacity: 1;
 }
 
+/* No hover on touch devices — keep the button visible. */
+@media (hover: none) {
+  .editor-toolbar .format-btn {
+    opacity: 1;
+  }
+}
+
 .editor-host {
   flex: 1;
   min-height: 0;

--- a/jbook/packages/local-client/src/components/example-text.css
+++ b/jbook/packages/local-client/src/components/example-text.css
@@ -58,3 +58,10 @@
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 768px) {
+  .guide-strip {
+    padding: 16px;
+    gap: 16px;
+  }
+}

--- a/jbook/packages/local-client/src/components/notebook-header.css
+++ b/jbook/packages/local-client/src/components/notebook-header.css
@@ -73,3 +73,22 @@
     row-gap: 8px;
   }
 }
+
+/* Mobile: the wrapped header is 2–3 rows tall, so it scrolls away instead of
+   staying stuck over a small screen; tighter padding and buttons to match. */
+@media (max-width: 768px) {
+  .notebook-header {
+    position: static;
+    padding: 10px 16px;
+    gap: 10px;
+  }
+  .notebook-header .btn {
+    font-size: 13px;
+    padding: 6px 10px;
+  }
+  .notebook-header .btn-icon {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+}

--- a/jbook/packages/local-client/src/components/resizable.css
+++ b/jbook/packages/local-client/src/components/resizable.css
@@ -33,4 +33,15 @@
   cursor: row-resize;
   position: relative;
   z-index: 2;
+  /* A drag on the handle resizes; without this the browser scrolls instead. */
+  touch-action: none;
+}
+
+/* Touch: a wider grab strip (still a 2px visible line). */
+@media (pointer: coarse) {
+  .react-resizable-handle-s {
+    height: 18px;
+    margin-top: -18px;
+    padding: 16px 0 0;
+  }
 }

--- a/jbook/packages/local-client/src/components/text-editor.css
+++ b/jbook/packages/local-client/src/components/text-editor.css
@@ -136,3 +136,25 @@
 .text-editor.editing .w-md-editor-preview .wmde-markdown {
   padding: 14px;
 }
+
+/* Mobile: source over preview instead of side-by-side half-widths. The
+   library's fixed 200px inline height would squeeze the stacked panes, so
+   the editor grows with its content instead. */
+@media (max-width: 768px) {
+  .text-editor.editing .w-md-editor {
+    height: auto !important;
+  }
+  .text-editor.editing .w-md-editor-content {
+    display: flex;
+    flex-direction: column;
+  }
+  .text-editor.editing .w-md-editor-area {
+    width: 100% !important;
+    min-height: 140px;
+  }
+  .text-editor.editing .w-md-editor-preview {
+    width: 100% !important;
+    border-left: 0;
+    border-top: 2px solid var(--color-divider);
+  }
+}

--- a/jbook/packages/local-client/src/constants.ts
+++ b/jbook/packages/local-client/src/constants.ts
@@ -26,3 +26,8 @@ export const MAX_CONSOLE_ENTRIES = 200;
 // The client edits whatever file local-api was started with; the API does
 // not expose the name, so the header and exports use the CLI's default.
 export const NOTEBOOK_FILENAME = 'notebook.js';
+
+// Below this width the code cell stacks editor over preview instead of
+// splitting side-by-side (two ~350px panes stop being usable). The CSS media
+// queries hardcode the same 768px — keep them in sync when changing this.
+export const MOBILE_BREAKPOINT_PX = 768;

--- a/jbook/packages/local-client/src/hooks/use-media-query.ts
+++ b/jbook/packages/local-client/src/hooks/use-media-query.ts
@@ -1,0 +1,27 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { MOBILE_BREAKPOINT_PX } from '../constants';
+
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`;
+
+const useMediaQuery = (query: string): boolean => {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', onChange);
+      // Some embedded/emulated viewports resize without firing MQL change
+      // events; re-reading on window resize covers them (React bails out
+      // when the snapshot is unchanged).
+      window.addEventListener('resize', onChange);
+      return () => {
+        mql.removeEventListener('change', onChange);
+        window.removeEventListener('resize', onChange);
+      };
+    },
+    [query]
+  );
+
+  return useSyncExternalStore(subscribe, () => window.matchMedia(query).matches);
+};
+
+// True on viewports where the code cell should stack editor over preview.
+export const useIsMobile = () => useMediaQuery(MOBILE_QUERY);

--- a/jbook/packages/local-client/src/test-setup.ts
+++ b/jbook/packages/local-client/src/test-setup.ts
@@ -5,3 +5,19 @@ import { cleanup } from '@testing-library/react';
 // Testing Library only auto-registers its cleanup when a global afterEach
 // exists (vitest globals are off here), so register it explicitly.
 afterEach(cleanup);
+
+// jsdom has no matchMedia; components render the desktop layout in tests.
+// (Guarded: some suites run in the node environment, where window is absent.)
+if (typeof window !== 'undefined') {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    } as MediaQueryList);
+}


### PR DESCRIPTION
The hosted demo is now the app's front door, and it shipped with almost no responsive CSS — this makes the notebook usable on phones (verified at 375×812, light and dark; desktop layout unchanged).

## Changes

- **Code cells stack editor over preview on ≤768px.** `code-cell.tsx` skips the horizontal split-resizer on mobile via a new `useIsMobile` hook (`useSyncExternalStore` + `matchMedia`, with a window-resize fallback for embedded viewports that don't fire MQL change events); CSS gives each pane half the cell height. The vertical cell-height resizer keeps working, with a wider grab strip and `touch-action: none` on coarse pointers so drags resize instead of scrolling.
- **Markdown cells stack source over preview** in edit mode, and the editor grows with its content instead of the library's fixed 200px inline height.
- **Header** goes non-sticky and compact on mobile (wrapped to 2–3 rows it would eat a third of a phone screen); page gutters drop 32px→16px (meta bar, cell list, empty state, guide strip).
- **Touch affordances:** cell action buttons 28→36px at near-full opacity on coarse pointers; the hover-revealed Format button is always visible on touch devices.
- **Test infra:** guarded `matchMedia` stub in `test-setup.ts` (jsdom lacks it; node-env suites have no `window`); `MOBILE_BREAKPOINT_PX` documented in `constants.ts` next to its CSS mirror.

## Testing

- 118/118 vitest tests pass; `tsc --noEmit` clean; `build:demo` succeeds.
- Verified in-browser at mobile and desktop widths: stacked panes, no horizontal page overflow, dark mode, markdown edit mode.
- Not verifiable in the sandboxed browser: live desktop↔mobile transitions (its emulation fires neither `resize` nor MQL change events; real browsers fire both). Worth a quick check on a real phone once the demo redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)