### PR TITLE
CLI update notice on serve

### DIFF
--- a/jbook/packages/cli/src/commands/serve.ts
+++ b/jbook/packages/cli/src/commands/serve.ts
@@ -2,6 +2,8 @@ import path from "path";
 import { Command } from "commander";
 import { serve } from "@my-scrapbook/local-api";
 import { openBrowser } from "../open-browser";
+import { notifyIfOutdated } from "../update-check";
+import { version } from "../version";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -27,6 +29,10 @@ export const serveCommand = new Command()
         console.log(`Opened ${filename}. Edit it at ${url}`);
         if (options.open) {
           openBrowser(url);
+        }
+        // Only for humans at a terminal — stays quiet in scripts and CI.
+        if (process.stdout.isTTY) {
+          void notifyIfOutdated(version);
         }
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;

--- a/jbook/packages/cli/src/index.ts
+++ b/jbook/packages/cli/src/index.ts
@@ -3,10 +3,7 @@ import { program } from 'commander';
 import { serveCommand } from './commands/serve';
 import { exportCommand } from './commands/export';
 import { importCommand } from './commands/import';
-
-// Resolved at runtime relative to dist/index.js (esbuild inlines it into the
-// published bundle), so the reported version always matches the package.
-const { version } = require('../package.json') as { version: string };
+import { version } from './version';
 
 program
   .name('my-scrapbook')

--- a/jbook/packages/cli/src/update-check.test.ts
+++ b/jbook/packages/cli/src/update-check.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { notifyIfOutdated } from './update-check';
+
+const mockRegistry = (body: unknown, ok = true) =>
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok, json: async () => body }))
+  );
+
+describe('notifyIfOutdated', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('prints a notice when the registry has a newer version', async () => {
+    mockRegistry({ version: '3.12.0' });
+    await notifyIfOutdated('3.11.0');
+
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(logSpy.mock.calls[0][0]).toContain('3.12.0');
+    expect(logSpy.mock.calls[0][0]).toContain('3.11.0');
+  });
+
+  it('compares numerically, not lexically', async () => {
+    mockRegistry({ version: '3.11.0' });
+    await notifyIfOutdated('3.9.0');
+
+    expect(logSpy).toHaveBeenCalledOnce();
+  });
+
+  it('stays quiet when up to date', async () => {
+    mockRegistry({ version: '3.11.0' });
+    await notifyIfOutdated('3.11.0');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when local is ahead of the registry', async () => {
+    mockRegistry({ version: '3.11.0' });
+    await notifyIfOutdated('3.12.0');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on a non-ok response', async () => {
+    mockRegistry({}, false);
+    await notifyIfOutdated('3.11.0');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on malformed registry data', async () => {
+    mockRegistry({ version: 'not-a-version' });
+    await notifyIfOutdated('3.11.0');
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when fetch rejects (offline)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      })
+    );
+
+    await expect(notifyIfOutdated('3.11.0')).resolves.toBeUndefined();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/jbook/packages/cli/src/update-check.ts
+++ b/jbook/packages/cli/src/update-check.ts
@@ -1,0 +1,34 @@
+const REGISTRY_LATEST = 'https://registry.npmjs.org/my-scrapbook/latest';
+const TIMEOUT_MS = 2000;
+
+// Plain x.y.z comparison — that's all this package ever publishes. Anything
+// non-numeric compares NaN, every branch is false, and no notice prints.
+const isNewer = (latest: string, current: string): boolean => {
+  const a = latest.split('.').map(Number);
+  const b = current.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] || 0) > (b[i] || 0)) return true;
+    if ((a[i] || 0) < (b[i] || 0)) return false;
+  }
+  return false;
+};
+
+// Prints a one-line notice when a newer version is on npm. Fire-and-forget:
+// offline, slow, or broken registries must never break or delay serving a
+// notebook, so every failure path is silent.
+export const notifyIfOutdated = async (current: string): Promise<void> => {
+  try {
+    const res = await fetch(REGISTRY_LATEST, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return;
+    const { version: latest } = (await res.json()) as { version?: string };
+    if (latest && isNewer(latest, current)) {
+      console.log(
+        `A newer my-scrapbook is available: ${latest} (you have ${current}). Update: npm i -g my-scrapbook@latest`
+      );
+    }
+  } catch {
+    // silent by design
+  }
+};

--- a/jbook/packages/cli/src/version.ts
+++ b/jbook/packages/cli/src/version.ts
@@ -1,0 +1,3 @@
+// Resolved at runtime relative to dist/index.js (this file bundles into it),
+// so the reported version always matches the installed package.
+export const { version } = require('../package.json') as { version: string };


### PR DESCRIPTION
`serve` now prints a one-liner when a newer my-scrapbook is on npm — top item on TODO.md's Future Considerations list, and it starts paying off with the next release.

- New `update-check.ts`: fetches `registry.npmjs.org/my-scrapbook/latest` (2s cap via `AbortSignal.timeout`), numeric x.y.z compare, prints `A newer my-scrapbook is available: X (you have Y). Update: npm i -g my-scrapbook@latest`. Every failure path (offline, slow, non-ok, malformed) is silent by design — the notice must never break or delay serving a notebook.
- Gated on `process.stdout.isTTY`, so scripts and CI stay quiet. Only `serve` checks — short-lived commands (`export`, `import`) would have their exit delayed by a pending fetch.
- The `require('../package.json')` version read moves from `index.ts` to a shared `version.ts` (same runtime resolution relative to `dist/index.js`) so `serve` can report the current version.
- 7 unit tests (newer/equal/ahead/non-ok/malformed/offline, numeric-vs-lexical compare). 47/47 CLI tests green, `tsc --noEmit` clean; verified the esbuild bundle still reports `--version` correctly and the notice prints against the real registry when given an old current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)