### PR TITLE
Version-pinned imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Version-pinned imports.** `import _ from 'lodash@4'` fetches that version instead of the latest — any exact version or semver range unpkg understands works, on scoped packages (`@scope/pkg@2`) and subpaths (`bulma@0.9/css/bulma.css`) too. Pinned and bare imports of the same package cache separately, so pinning is the explicit way to control a version while clearing the module cache remains the way to float bare imports forward.
+
+### Fixed
+- A failed package fetch used to surface as a bare `Network Error` in the preview. It now names the import and the likely cause: a bad package name or version (`Could not fetch 'lodash@99' from unpkg — check the package name and version`) or being offline with an uncached module.
+
 ## 3.12.0 — 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This is an interactive coding environment. Write JavaScript or TypeScript, see i
 - Cells share one file — a variable defined in cell #1 works in every cell below it
 - Call the built-in `show()` with a React component, string, number, or object to render it in the preview
 - `console.log` output shows up in a console panel under the preview
-- Import any npm package — bundling happens right in the browser, and packages you've used keep working offline
+- Import any npm package — bundling happens right in the browser, and packages you've used keep working offline. Pin a version with `import _ from 'lodash@4'` (any semver range or exact version unpkg understands)
 - Click **Format** in any code cell and Prettier tidies it up
 - Reorder cells with the grip handle (or the arrows), and undo any of it with Ctrl/Cmd+Z
 

--- a/TODO.md
+++ b/TODO.md
@@ -343,14 +343,14 @@
 ### Future Considerations
 
 Shipped from the original list: ~~dark mode~~ (3.10), ~~export to static
-HTML~~ (3.9), ~~mobile responsive design~~ (PR #64 — code and markdown cells
-stack their panes on ≤768px, compact non-sticky header, touch-sized targets).
-Markdown export (3.3) and import (3.11) also cover moving notebooks in and
-out as plain files.
+HTML~~ (3.9), ~~mobile responsive design~~ (3.12 — code and markdown cells
+stack their panes on ≤768px, compact non-sticky header, touch-sized targets),
+~~CLI update notice~~ (3.12), ~~version pinning in imports~~ (unreleased —
+`lodash@4` works on bare, scoped, and subpath imports; a package version
+management UI could still build on this). Markdown export (3.3) and import
+(3.11) also cover moving notebooks in and out as plain files.
 
 Still open, roughly by value-for-effort:
-- **CLI update notice** — print a one-liner when a newer version is on npm; small, standard for CLIs
-- **Version pinning in imports** (e.g. `import x from 'lodash@4'`) — pairs naturally with the IndexedDB module cache, which currently pins whatever version was fetched first; a package version management UI would build on this
 - Import from GitHub gists (export already works via markdown/HTML)
 - Syntax themes
 - Multi-file notebooks (import from other notebooks)

--- a/jbook/packages/local-client/src/bundler/module-cache.ts
+++ b/jbook/packages/local-client/src/bundler/module-cache.ts
@@ -4,7 +4,10 @@ import localForage from 'localforage';
 // (IndexedDB), keyed by URL. Cache hits skip the network entirely, which is
 // what makes bundling previously-used packages work offline. Entries are
 // pinned until cleared: 'react' resolves to whatever version unpkg served
-// when it was first fetched.
+// when it was first fetched. Version-pinned imports ('lodash@4') are
+// distinct keys, so they never collide with a bare import of the same
+// package — pinning is the explicit way to control a version, clearing the
+// cache is the way to float bare imports forward.
 export const moduleCache = localForage.createInstance({
   name: 'filecache',
 });

--- a/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.test.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.test.ts
@@ -84,6 +84,41 @@ describe('fetch plugin', () => {
     );
   });
 
+  it('names the import when unpkg answers 404', async () => {
+    vi.mocked(axios.get).mockRejectedValue({ response: { status: 404 } });
+    vi.mocked(axios.isAxiosError).mockReturnValue(true);
+    const load = makeLoader('');
+
+    await expect(load({ path: 'https://unpkg.com/lodash@99' })).rejects.toThrow(
+      "Could not fetch 'lodash@99' from unpkg — check the package name and version"
+    );
+  });
+
+  it('says a response-less failure is a bad specifier while online', async () => {
+    // unpkg 404s can be CORS-blocked, so a bad version often has no response.
+    vi.mocked(axios.get).mockRejectedValue(new Error('Network Error'));
+    vi.mocked(axios.isAxiosError).mockReturnValue(false);
+    vi.stubGlobal('navigator', { onLine: true });
+    const load = makeLoader('');
+
+    await expect(load({ path: 'https://unpkg.com/lodash@99' })).rejects.toThrow(
+      "Could not fetch 'lodash@99' from unpkg — check the package name and version"
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('says a response-less failure is the network while offline', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('Network Error'));
+    vi.mocked(axios.isAxiosError).mockReturnValue(false);
+    vi.stubGlobal('navigator', { onLine: false });
+    const load = makeLoader('');
+
+    await expect(load({ path: 'https://unpkg.com/lodash' })).rejects.toThrow(
+      "Could not fetch 'lodash' — you're offline and it isn't in the module cache yet"
+    );
+    vi.unstubAllGlobals();
+  });
+
   it('wraps CSS in a style-injecting script with escaped content', async () => {
     vi.mocked(axios.get).mockResolvedValue({
       data: '.button {\n  color: "red";\n}',

--- a/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/fetch-plugin.ts
@@ -2,6 +2,33 @@ import * as esbuild from 'esbuild-wasm';
 import axios from 'axios';
 import { moduleCache as fileCache } from '../module-cache';
 
+// A failed unpkg fetch surfaces from axios as a bare "Network Error" (unpkg's
+// 404s can be CORS-blocked, so there is often no response object) — useless
+// in the preview pane. Rethrow with the import specifier and a likely cause;
+// esbuild shows the message at the failing import.
+const fetchModule = async (url: string) => {
+  try {
+    return await axios.get(url);
+  } catch (err) {
+    const specifier = url.replace('https://unpkg.com/', '');
+    const status =
+      axios.isAxiosError(err) && err.response
+        ? err.response.status
+        : undefined;
+    if (status === 404 || (status === undefined && navigator.onLine)) {
+      throw new Error(
+        `Could not fetch '${specifier}' from unpkg — check the package name and version`
+      );
+    }
+    if (status === undefined) {
+      throw new Error(
+        `Could not fetch '${specifier}' — you're offline and it isn't in the module cache yet`
+      );
+    }
+    throw new Error(`Could not fetch '${specifier}' — unpkg answered ${status}`);
+  }
+};
+
 export const fetchPlugin = (inputCode: string) => {
   return {
     name: 'fetch-plugin',
@@ -26,7 +53,7 @@ export const fetchPlugin = (inputCode: string) => {
       });
 
       build.onLoad({ filter: /.css$/ }, async (args: any) => {
-        const { data, request } = await axios.get(args.path);
+        const { data, request } = await fetchModule(args.path);
         const escaped = data
           .replace(/\n/g, '')
           .replace(/"/g, '\\"')
@@ -48,7 +75,7 @@ export const fetchPlugin = (inputCode: string) => {
       });
 
       build.onLoad({ filter: /.*/ }, async (args: any) => {
-        const { data, request } = await axios.get(args.path);
+        const { data, request } = await fetchModule(args.path);
 
         const result: esbuild.OnLoadResult = {
           loader: 'jsx',

--- a/jbook/packages/local-client/src/bundler/plugins/unpkg-path-plugin.test.ts
+++ b/jbook/packages/local-client/src/bundler/plugins/unpkg-path-plugin.test.ts
@@ -46,6 +46,28 @@ describe('unpkg path plugin', () => {
     });
   });
 
+  it('passes version-pinned specifiers through to unpkg', async () => {
+    // unpkg resolves the semver range server-side, so the URL carries the
+    // pin verbatim: unpkg.com/lodash@4 answers with lodash@4.x's code.
+    const resolve = makeResolver();
+    expect(await resolve({ path: 'lodash@4' })).toEqual({
+      namespace: 'a',
+      path: 'https://unpkg.com/lodash@4',
+    });
+    expect(await resolve({ path: 'axios@0.27.2' })).toEqual({
+      namespace: 'a',
+      path: 'https://unpkg.com/axios@0.27.2',
+    });
+    expect(await resolve({ path: '@tanstack/react-query@5' })).toEqual({
+      namespace: 'a',
+      path: 'https://unpkg.com/@tanstack/react-query@5',
+    });
+    expect(await resolve({ path: 'bulma@0.9/css/bulma.css' })).toEqual({
+      namespace: 'a',
+      path: 'https://unpkg.com/bulma@0.9/css/bulma.css',
+    });
+  });
+
   it('resolves relative paths against the importing module directory', () => {
     const resolve = makeResolver();
     expect(

--- a/jbook/packages/local-client/src/components/example-text.tsx
+++ b/jbook/packages/local-client/src/components/example-text.tsx
@@ -13,7 +13,10 @@ const GUIDE_ITEMS: React.ReactNode[] = [
     Call <code>show()</code> to render a component, string or number in the
     preview.
   </>,
-  <>Import any npm package — bundling happens in the browser.</>,
+  <>
+    Import any npm package — bundling happens in the browser. Pin a version
+    with <code>lodash@4</code>.
+  </>,
   <>
     Code cells accept TypeScript too — types are stripped before the code
     runs.

--- a/jbook/packages/local-client/src/persistence/demo-seed.ts
+++ b/jbook/packages/local-client/src/persistence/demo-seed.ts
@@ -16,7 +16,7 @@ This is an interactive coding environment. Write JavaScript or TypeScript, see i
 - Cells share one file — a variable defined in cell #1 works in every cell below it
 - Call the built-in \`show()\` with a React component, string, number, or object to render it in the preview
 - \`console.log\` output shows up in a console panel under the preview
-- Import any npm package — bundling happens right in the browser, and packages you've used keep working offline
+- Import any npm package — bundling happens right in the browser, and packages you've used keep working offline. Pin a version with \`import _ from 'lodash@4'\`
 - Click **Format** in any code cell and Prettier tidies it up
 - Reorder cells with the grip handle (or the arrows), and undo any of it with Ctrl/Cmd+Z
 


### PR DESCRIPTION
Ships the last quick item on the roadmap: `import _ from 'lodash@4'` fetches that version instead of the latest.

The interesting finding: unpkg resolves semver ranges server-side, so pinning already worked incidentally — verified live with `lodash@3` (single-file), `axios@0.27` (multi-file, nested requires), and subpath/scoped forms. What was missing was making it a *supported* feature:

- **Tests**: pinned bare (`lodash@4`), exact (`axios@0.27.2`), scoped (`@tanstack/react-query@5`), and subpath (`bulma@0.9/css/bulma.css`) specifiers in the unpkg-path-plugin suite; three new fetch-plugin error cases.
- **Error UX (the real gap)**: a bad name or version used to surface as `[plugin: fetch-plugin] Network Error` — unpkg's 404s can be CORS-blocked, so there's often no response object at all. Failed fetches now name the import and the likely cause: `Could not fetch 'lodash@99' from unpkg — check the package name and version`, or an offline message (via `navigator.onLine`) when the module isn't cached yet.
- **Docs**: guide strip item, README, demo seed notebook, module-cache comment (pinned and bare imports cache under distinct keys — pinning is explicit version control, clearing the cache floats bare imports forward), changelog Unreleased entries, TODO bookkeeping (this + earlier items marked shipped).

122/122 local-client tests green, `tsc --noEmit` clean; error message verified live in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)