### PR TITLE
Prepare the 3.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.13.0 — 2026-08-13
 
 ### Added
 - **Version-pinned imports.** `import _ from 'lodash@4'` fetches that version instead of the latest — any exact version or semver range unpkg understands works, on scoped packages (`@scope/pkg@2`) and subpaths (`bulma@0.9/css/bulma.css`) too. Pinned and bare imports of the same package cache separately, so pinning is the explicit way to control a version while clearing the module cache remains the way to float bare imports forward.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.12.0"
+  "version": "3.13.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.13.0 — ships version-pinned imports and the named fetch errors (#68).

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.13.0; `local-api` stays 3.8.0, `types` 3.0.0; `lerna.json` and lockfile sync.
- Changelog: Unreleased becomes `3.13.0 — 2026-08-13`.

Release-verified locally: 179 tests green across the workspace; pack-and-install smoke test passes end-to-end and the installed CLI reports 3.13.0.

After merge: push the `v3.13.0` tag; `publish.yml` publishes to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)