### PR TITLE
Import notebooks from GitHub gists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Import from GitHub gists.** `my-scrapbook import https://gist.github.com/user/abc123` creates a notebook from a gist. The most notebook-like file wins: an exported `notebook.js` imports exactly, a markdown file goes through the markdown importer, and plain JS/TS sources become code cells (with a filename header cell when there are several). `--file <name>` picks a specific file when the gist has several candidates; `-o` and `-f` work as for markdown imports, and files the API truncates (~1 MB) are refetched whole from their raw URL.
+
 ## 3.13.0 — 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ npx my-scrapbook import notes.md -o scratch.js
 
 - `export` and `import` are inverses, so a notebook survives the round trip unchanged — edit your notebook as markdown in another tool and bring it back, or bootstrap a notebook from a README.
 
+### …or from a GitHub gist
+
+- `import` also accepts a gist URL:
+
+```
+npx my-scrapbook import https://gist.github.com/user/abc123
+```
+
+- It picks the most notebook-like file automatically — an exported `notebook.js` wins (it round-trips exactly), then a markdown file, then JS/TS sources become code cells (with a filename header cell when there are several). `--file <name>` picks a specific file when the gist has several candidates, and `-o`/`-f` work as for markdown imports.
+
 ## Share a notebook as a live HTML page
 
 - Click **Export HTML** in the notebook's header to download the whole notebook as a single **notebook.html** file.
@@ -92,7 +102,7 @@ npx my-scrapbook import notes.md -o scratch.js
 
 ## What's new in 3.11
 
-- **Import from markdown.** `npx my-scrapbook import notes.md` turns a markdown file into a notebook — the inverse of `export`, and a round trip through both leaves a notebook unchanged. See "Import a notebook from Markdown" above.
+- **Import from markdown or a gist.** `npx my-scrapbook import notes.md` turns a markdown file into a notebook — the inverse of `export`, and a round trip through both leaves a notebook unchanged. A gist URL works too: `npx my-scrapbook import https://gist.github.com/user/abc123`. See "Import a notebook from Markdown" above.
 - The esbuild WebAssembly binary now falls back to unpkg (version-pinned) if the locally shipped copy fails to load, and CI now tests every supported Node version (20/22/24) on Linux, Windows, and macOS.
 
 ## What's new in 3.10

--- a/TODO.md
+++ b/TODO.md
@@ -350,8 +350,11 @@ stack their panes on ≤768px, compact non-sticky header, touch-sized targets),
 management UI could still build on this). Markdown export (3.3) and import
 (3.11) also cover moving notebooks in and out as plain files.
 
+Shipped since: ~~import from GitHub gists~~ (unreleased — `my-scrapbook
+import <gist url>`, picking notebook > markdown > JS/TS sources, with
+`--file` to disambiguate).
+
 Still open, roughly by value-for-effort:
-- Import from GitHub gists (export already works via markdown/HTML)
 - Syntax themes
 - Multi-file notebooks (import from other notebooks)
 - Custom bundler configurations per notebook

--- a/jbook/packages/cli/src/commands/import.test.ts
+++ b/jbook/packages/cli/src/commands/import.test.ts
@@ -121,4 +121,116 @@ describe('import command parsing', () => {
     });
     expect(fs.readFile).not.toHaveBeenCalled();
   });
+
+  it('rejects --file for local imports', async () => {
+    await expect(
+      run(['import', 'notes.md', '--file', 'a.md'])
+    ).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('--file only applies to gist imports')
+    );
+  });
+});
+
+describe('import command with a gist URL', () => {
+  const gistResponse = (files: Record<string, string>) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      files: Object.fromEntries(
+        Object.entries(files).map(([filename, content]) => [
+          filename,
+          { filename, content, truncated: false, raw_url: '' },
+        ])
+      ),
+    }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.access).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('imports a markdown gist, naming the output after its file', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => gistResponse({ 'notes.md': MARKDOWN }))
+    );
+
+    await run(['import', 'https://gist.github.com/danny/abc123']);
+
+    expect(fs.readFile).not.toHaveBeenCalled();
+    const [outPath, json] = vi.mocked(fs.writeFile).mock.calls[0];
+    expect(outPath).toBe(path.resolve(process.cwd(), 'notes.js'));
+    const cells = JSON.parse(json as string);
+    expect(cells[1]).toMatchObject({ type: 'code', content: 'show(1);' });
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Imported gist (notes.md) to notes.js')
+    );
+  });
+
+  it('--file picks a gist file and -o still names the output', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        gistResponse({ 'a.md': '# a', 'b.md': '# b\n\n```js\nshow(9);\n```' })
+      )
+    );
+
+    await run([
+      'import',
+      'https://gist.github.com/abc123',
+      '--file',
+      'b.md',
+      '-o',
+      'nb.js',
+    ]);
+
+    const [outPath, json] = vi.mocked(fs.writeFile).mock.calls[0];
+    expect(outPath).toBe(path.resolve(process.cwd(), 'nb.js'));
+    expect(JSON.parse(json as string)[1]).toMatchObject({
+      type: 'code',
+      content: 'show(9);',
+    });
+  });
+
+  it('still refuses to overwrite an existing notebook', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => gistResponse({ 'notes.md': MARKDOWN }))
+    );
+    vi.mocked(fs.access).mockResolvedValue(undefined);
+
+    await expect(
+      run(['import', 'https://gist.github.com/danny/abc123'])
+    ).rejects.toThrow('exit:1');
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('reports fetch failures and exits 1', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404 }))
+    );
+
+    await expect(
+      run(['import', 'https://gist.github.com/danny/abc123'])
+    ).rejects.toThrow('exit:1');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Could not import the gist')
+    );
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
 });

--- a/jbook/packages/cli/src/commands/import.ts
+++ b/jbook/packages/cli/src/commands/import.ts
@@ -2,29 +2,91 @@ import fs from "fs/promises";
 import path from "path";
 import { Command } from "commander";
 import { markdownToCells } from "../markdown";
+import { fetchGistFiles, gistToCells, parseGistUrl } from "../gist";
+
+// Never silently replace a notebook: they are user data.
+const refuseExisting = async (outPath: string, outFile: string) => {
+  let exists = true;
+  try {
+    await fs.access(outPath);
+  } catch {
+    exists = false;
+  }
+  if (exists) {
+    console.error(
+      `${outFile} already exists. Pass -f to overwrite it, or -o to pick a different name.`
+    );
+    process.exit(1);
+  }
+};
+
+const writeNotebook = async (
+  outPath: string,
+  outFile: string,
+  source: string,
+  cells: ReturnType<typeof markdownToCells>
+) => {
+  await fs.writeFile(outPath, JSON.stringify(cells), "utf-8");
+  const codeCount = cells.filter((cell) => cell.type === "code").length;
+  console.log(
+    `Imported ${source} to ${outFile} (${codeCount} code, ${
+      cells.length - codeCount
+    } text cells). Run "my-scrapbook serve ${outFile}" to open it.`
+  );
+};
 
 export const importCommand = new Command()
-  .command("import [filename]")
+  .command("import [source]")
   .description(
-    "Create a notebook from a markdown file (default: notebook.md)"
+    "Create a notebook from a markdown file or GitHub gist URL (default: notebook.md)"
   )
   .option(
     "-o, --out <file>",
-    "notebook file to write (default: the markdown name with .js)"
+    "notebook file to write (default: the source name with .js)"
   )
   .option("-f, --force", "overwrite the output notebook if it already exists")
+  .option(
+    "--file <name>",
+    "which file of a gist to import, when it has several"
+  )
   .action(
     async (
-      filename = "notebook.md",
-      options: { out?: string; force?: boolean }
+      source = "notebook.md",
+      options: { out?: string; force?: boolean; file?: string }
     ) => {
-      const inputPath = path.resolve(process.cwd(), filename);
-      const outFile = options.out ?? filename.replace(/\.[^./\\]*$/, "") + ".js";
+      const gistId = parseGistUrl(source);
+
+      if (gistId) {
+        try {
+          const files = await fetchGistFiles(gistId);
+          const { filename, cells } = gistToCells(files, options.file);
+          const outFile =
+            options.out ?? filename.replace(/\.[^./\\]*$/, "") + ".js";
+          const outPath = path.resolve(process.cwd(), outFile);
+          if (!options.force) {
+            await refuseExisting(outPath, outFile);
+          }
+          await writeNotebook(outPath, outFile, `gist (${filename})`, cells);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Could not import the gist: ${message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
+      if (options.file) {
+        console.error(`--file only applies to gist imports.`);
+        process.exit(1);
+      }
+
+      const inputPath = path.resolve(process.cwd(), source);
+      const outFile = options.out ?? source.replace(/\.[^./\\]*$/, "") + ".js";
       const outPath = path.resolve(process.cwd(), outFile);
 
       if (outPath === inputPath) {
         console.error(
-          `The output file would overwrite the markdown file itself (${filename}). Pick a different -o path.`
+          `The output file would overwrite the markdown file itself (${source}). Pick a different -o path.`
         );
         process.exit(1);
       }
@@ -35,42 +97,23 @@ export const importCommand = new Command()
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code === "ENOENT") {
-          console.error(`No markdown file found at ${filename}.`);
+          console.error(`No markdown file found at ${source}.`);
         } else {
           const message = err instanceof Error ? err.message : String(err);
-          console.error(`Could not read ${filename}: ${message}`);
+          console.error(`Could not read ${source}: ${message}`);
         }
         process.exit(1);
       }
 
-      // Notebooks are user data: never silently replace one.
       if (!options.force) {
-        let exists = true;
-        try {
-          await fs.access(outPath);
-        } catch {
-          exists = false;
-        }
-        if (exists) {
-          console.error(
-            `${outFile} already exists. Pass -f to overwrite it, or -o to pick a different name.`
-          );
-          process.exit(1);
-        }
+        await refuseExisting(outPath, outFile);
       }
 
       try {
-        const cells = markdownToCells(raw);
-        await fs.writeFile(outPath, JSON.stringify(cells), "utf-8");
-        const codeCount = cells.filter((cell) => cell.type === "code").length;
-        console.log(
-          `Imported ${filename} to ${outFile} (${codeCount} code, ${
-            cells.length - codeCount
-          } text cells). Run "my-scrapbook serve ${outFile}" to open it.`
-        );
+        await writeNotebook(outPath, outFile, source, markdownToCells(raw));
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.error(`Could not import ${filename}: ${message}`);
+        console.error(`Could not import ${source}: ${message}`);
         process.exit(1);
       }
     }

--- a/jbook/packages/cli/src/gist.test.ts
+++ b/jbook/packages/cli/src/gist.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchGistFiles, gistToCells, parseGistUrl } from './gist';
+
+describe('parseGistUrl', () => {
+  it('accepts the URL forms users copy', () => {
+    expect(parseGistUrl('https://gist.github.com/danny/abc123def')).toBe(
+      'abc123def'
+    );
+    expect(parseGistUrl('https://gist.github.com/abc123def')).toBe('abc123def');
+    expect(
+      parseGistUrl('https://gist.github.com/danny/abc123def#file-notes-md')
+    ).toBe('abc123def');
+    expect(parseGistUrl('http://gist.github.com/danny/abc123def/')).toBe(
+      'abc123def'
+    );
+  });
+
+  it('rejects non-gist inputs so they fall through to the file path', () => {
+    expect(parseGistUrl('notebook.md')).toBeNull();
+    expect(parseGistUrl('docs/notes.md')).toBeNull();
+    expect(parseGistUrl('https://github.com/danny/repo')).toBeNull();
+    expect(parseGistUrl('https://gist.github.com/danny/not hex!')).toBeNull();
+  });
+});
+
+describe('gistToCells', () => {
+  const NOTEBOOK = JSON.stringify([
+    { id: '1', type: 'text', content: 'hi' },
+    { id: '2', type: 'code', content: 'show(1);' },
+  ]);
+  const MARKDOWN = '# Title\n\n```js\nshow(2);\n```\n';
+
+  it('an exported notebook wins over everything else', () => {
+    const { filename, cells } = gistToCells([
+      { filename: 'README.md', content: MARKDOWN },
+      { filename: 'notebook.js', content: NOTEBOOK },
+    ]);
+    expect(filename).toBe('notebook.js');
+    expect(cells).toHaveLength(2);
+    expect(cells[1]).toMatchObject({ type: 'code', content: 'show(1);' });
+  });
+
+  it('a lone markdown file imports as markdown', () => {
+    const { cells } = gistToCells([
+      { filename: 'notes.md', content: MARKDOWN },
+    ]);
+    expect(cells[0]).toMatchObject({ type: 'text', content: '# Title' });
+    expect(cells[1]).toMatchObject({ type: 'code', content: 'show(2);' });
+  });
+
+  it('several markdown files demand --file', () => {
+    expect(() =>
+      gistToCells([
+        { filename: 'a.md', content: '# a' },
+        { filename: 'b.md', content: '# b' },
+      ])
+    ).toThrow('--file');
+  });
+
+  it('a lone JS file becomes a single code cell', () => {
+    const { filename, cells } = gistToCells([
+      { filename: 'snippet.js', content: 'show(3);\n' },
+    ]);
+    expect(filename).toBe('snippet.js');
+    expect(cells).toEqual([
+      expect.objectContaining({ type: 'code', content: 'show(3);' }),
+    ]);
+  });
+
+  it('several JS files get filename header cells', () => {
+    const { cells } = gistToCells([
+      { filename: 'a.ts', content: 'const a = 1;' },
+      { filename: 'b.tsx', content: 'show(a);' },
+    ]);
+    expect(cells.map((c) => [c.type, c.content])).toEqual([
+      ['text', '**a.ts**'],
+      ['code', 'const a = 1;'],
+      ['text', '**b.tsx**'],
+      ['code', 'show(a);'],
+    ]);
+  });
+
+  it('a plain .js file that is not a notebook still imports as code', () => {
+    const { cells } = gistToCells([
+      { filename: 'script.js', content: 'console.log(1);' },
+    ]);
+    expect(cells).toEqual([
+      expect.objectContaining({ type: 'code', content: 'console.log(1);' }),
+    ]);
+  });
+
+  it('--file forces a specific file and names the others when missing', () => {
+    const files = [
+      { filename: 'README.md', content: MARKDOWN },
+      { filename: 'notebook.js', content: NOTEBOOK },
+    ];
+    const { filename, cells } = gistToCells(files, 'README.md');
+    expect(filename).toBe('README.md');
+    expect(cells[0]).toMatchObject({ type: 'text', content: '# Title' });
+
+    expect(() => gistToCells(files, 'nope.md')).toThrow(
+      'no file named nope.md (it has: README.md, notebook.js)'
+    );
+  });
+
+  it('rejects a gist with nothing importable', () => {
+    expect(() =>
+      gistToCells([{ filename: 'data.csv', content: 'a,b' }])
+    ).toThrow('nothing importable');
+  });
+});
+
+describe('fetchGistFiles', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the files of a gist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          files: {
+            'a.md': {
+              filename: 'a.md',
+              content: '# a',
+              truncated: false,
+              raw_url: 'https://x/a.md',
+            },
+          },
+        }),
+      }))
+    );
+
+    expect(await fetchGistFiles('abc')).toEqual([
+      { filename: 'a.md', content: '# a' },
+    ]);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/gists/abc',
+      expect.anything()
+    );
+  });
+
+  it('fetches the raw URL for truncated files', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        url.includes('api.github.com')
+          ? {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                files: {
+                  'big.js': {
+                    filename: 'big.js',
+                    content: 'cut off',
+                    truncated: true,
+                    raw_url: 'https://raw/big.js',
+                  },
+                },
+              }),
+            }
+          : { ok: true, status: 200, text: async () => 'the whole thing' }
+      )
+    );
+
+    expect(await fetchGistFiles('abc')).toEqual([
+      { filename: 'big.js', content: 'the whole thing' },
+    ]);
+  });
+
+  it('says so when the gist does not exist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 404 }))
+    );
+    await expect(fetchGistFiles('abc')).rejects.toThrow('no such gist');
+  });
+
+  it('surfaces other GitHub errors by status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 403 }))
+    );
+    await expect(fetchGistFiles('abc')).rejects.toThrow('GitHub answered 403');
+  });
+});

--- a/jbook/packages/cli/src/gist.ts
+++ b/jbook/packages/cli/src/gist.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "crypto";
+import { Cell } from "@my-scrapbook/types";
+import { markdownToCells, parseNotebook } from "./markdown";
+
+// Gist URLs as users copy them: gist.github.com/<id> or
+// gist.github.com/<user>/<id>, with an optional #file-… fragment or trailing
+// path. Returns the gist id, or null when the input isn't a gist URL (the
+// import command then treats it as a local file path).
+export const parseGistUrl = (input: string): string | null => {
+  const match = input.match(
+    /^https?:\/\/gist\.github\.com\/(?:[\w-]+\/)?([0-9a-f]+)(?:[/#?].*)?$/i
+  );
+  return match ? match[1] : null;
+};
+
+export interface GistFile {
+  filename: string;
+  content: string;
+}
+
+interface GistApiFile {
+  filename: string;
+  content: string;
+  truncated: boolean;
+  raw_url: string;
+}
+
+export const fetchGistFiles = async (id: string): Promise<GistFile[]> => {
+  const res = await fetch(`https://api.github.com/gists/${id}`, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (res.status === 404) {
+    throw new Error("GitHub has no such gist — is it secret or deleted?");
+  }
+  if (!res.ok) {
+    throw new Error(`GitHub answered ${res.status}`);
+  }
+  const gist = (await res.json()) as {
+    files?: Record<string, GistApiFile>;
+  };
+  const files = Object.values(gist.files ?? {});
+  return Promise.all(
+    files.map(async (file) => ({
+      filename: file.filename,
+      // The API truncates contents around 1 MB; the raw URL has it whole.
+      content: file.truncated
+        ? await (await fetch(file.raw_url)).text()
+        : file.content,
+    }))
+  );
+};
+
+const MARKDOWN_EXT = /\.(md|markdown)$/i;
+const CODE_EXT = /\.(js|jsx|ts|tsx)$/i;
+
+const textCell = (content: string): Cell => ({
+  id: randomUUID(),
+  type: "text",
+  content,
+});
+const codeCell = (content: string): Cell => ({
+  id: randomUUID(),
+  type: "code",
+  content: content.trimEnd(),
+});
+
+// An exported notebook.js is a JSON cell array; anything else is not.
+const asNotebook = (file: GistFile): Cell[] | null => {
+  try {
+    return parseNotebook(file.content);
+  } catch {
+    return null;
+  }
+};
+
+const cellsForFile = (file: GistFile): Cell[] => {
+  if (MARKDOWN_EXT.test(file.filename)) return markdownToCells(file.content);
+  return asNotebook(file) ?? [codeCell(file.content)];
+};
+
+// Picks what to import from a gist. Precedence without --file: an exported
+// notebook (round-trips exactly), then a lone markdown file, then JS/TS
+// sources as code cells (with a filename header cell when there are several).
+export const gistToCells = (
+  files: GistFile[],
+  only?: string
+): { filename: string; cells: Cell[] } => {
+  const names = files.map((file) => file.filename).join(", ");
+
+  if (only) {
+    const file = files.find((file) => file.filename === only);
+    if (!file) {
+      throw new Error(`the gist has no file named ${only} (it has: ${names})`);
+    }
+    return { filename: file.filename, cells: cellsForFile(file) };
+  }
+
+  for (const file of files) {
+    const notebook = asNotebook(file);
+    if (notebook) return { filename: file.filename, cells: notebook };
+  }
+
+  const markdowns = files.filter((file) => MARKDOWN_EXT.test(file.filename));
+  if (markdowns.length === 1) {
+    return {
+      filename: markdowns[0].filename,
+      cells: markdownToCells(markdowns[0].content),
+    };
+  }
+  if (markdowns.length > 1) {
+    throw new Error(
+      `the gist has several markdown files — pick one with --file (it has: ${names})`
+    );
+  }
+
+  const sources = files.filter((file) => CODE_EXT.test(file.filename));
+  if (sources.length > 0) {
+    return {
+      filename: sources[0].filename,
+      cells: sources.flatMap((file) =>
+        sources.length > 1
+          ? [textCell(`**${file.filename}**`), codeCell(file.content)]
+          : [codeCell(file.content)]
+      ),
+    };
+  }
+
+  throw new Error(
+    `nothing importable — no notebook, markdown, or JS/TS file (it has: ${
+      names || "no files"
+    })`
+  );
+};


### PR DESCRIPTION
`my-scrapbook import` now accepts a gist URL — the last quick-ish item on the roadmap's Future Considerations.

- **URL forms**: `gist.github.com/<id>`, `gist.github.com/<user>/<id>`, with fragments/trailing paths ignored; anything else falls through to the existing local-file path.
- **File selection** (documented in README): an exported `notebook.js` wins (it round-trips exactly via `parseNotebook`), then a lone markdown file (through the existing markdown importer), then JS/TS sources become code cells — with a `**filename**` text-cell header when there are several. Ambiguous (multiple markdown) or empty gists get errors that list the gist's files; `--file <name>` forces a choice.
- **Robustness**: files the API truncates (~1 MB) are refetched whole from `raw_url`; 404 and other GitHub errors get specific messages; `--file` on a local import errors; the existing overwrite guard and `-o`/`-f` apply unchanged. Default output name comes from the chosen gist file (`notes.md` → `notes.js`).
- **Tests**: 19 new (URL parsing, selection precedence, truncation, error paths, command-level gist flows). 66/66 CLI tests green, 198 across the workspace, `tsc --noEmit` clean.
- **Verified against real gists**: a markdown gist imported into a working notebook, and a ruby-only gist produced the clean "nothing importable" error naming its files.

Changelog entry sits in Unreleased; TODO bookkeeping included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)