### PR TITLE
Prepare the 3.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.14.0 — 2026-08-13
 
 ### Added
 - **Import from GitHub gists.** `my-scrapbook import https://gist.github.com/user/abc123` creates a notebook from a gist. The most notebook-like file wins: an exported `notebook.js` imports exactly, a markdown file goes through the markdown importer, and plain JS/TS sources become code cells (with a filename header cell when there are several). `--file <name>` picks a specific file when the gist has several candidates; `-o` and `-f` work as for markdown imports, and files the API truncates (~1 MB) are refetched whole from their raw URL.

--- a/jbook/lerna.json
+++ b/jbook/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.13.0"
+  "version": "3.14.0"
 }

--- a/jbook/package-lock.json
+++ b/jbook/package-lock.json
@@ -14586,7 +14586,7 @@
     },
     "packages/cli": {
       "name": "my-scrapbook",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "license": "MIT",
       "dependencies": {
         "@my-scrapbook/local-api": "^3.0.0",
@@ -15127,7 +15127,7 @@
     },
     "packages/local-client": {
       "name": "@my-scrapbook/local-client",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/jbook/packages/cli/package.json
+++ b/jbook/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-scrapbook",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "An in-browser coding notebook: write JavaScript with npm imports and markdown docs, see it run live",
   "keywords": [
     "notebook",

--- a/jbook/packages/local-client/package.json
+++ b/jbook/packages/local-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-scrapbook/local-client",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "author": "Danny Sarco",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Release prep for 3.14.0 — ships gist import (#70).

- `my-scrapbook` and `@my-scrapbook/local-client` bump to 3.14.0; `local-api` stays 3.8.0, `types` 3.0.0; `lerna.json` and lockfile sync.
- Changelog: Unreleased becomes `3.14.0 — 2026-08-13`.

Release-verified locally: 198 tests green; pack-and-install smoke test passes and the installed CLI reports 3.14.0.

After merge: push the `v3.14.0` tag; `publish.yml` publishes to npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)